### PR TITLE
Second arg should be Bx for both OP_GETGLOBAL and OP_SETGLOBAL

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -224,7 +224,7 @@ inline static int op_loadf( mrb_vm *vm, uint32_t code, mrb_value *regs )
 inline static int op_getglobal( mrb_vm *vm, uint32_t code, mrb_value *regs )
 {
   int ra = GETARG_A(code);
-  int rb = GETARG_B(code);
+  int rb = GETARG_Bx(code);
   char *sym = find_irep_symbol(vm->pc_irep->ptr_to_sym, rb);
   mrb_sym sym_id = add_sym(sym);
   regs[ra] = global_object_get(sym_id);
@@ -246,7 +246,7 @@ inline static int op_getglobal( mrb_vm *vm, uint32_t code, mrb_value *regs )
 inline static int op_setglobal( mrb_vm *vm, uint32_t code, mrb_value *regs )
 {
   int ra = GETARG_A(code);
-  int rb = GETARG_B(code);
+  int rb = GETARG_Bx(code);
   char *sym = find_irep_symbol(vm->pc_irep->ptr_to_sym, rb);
   mrb_sym sym_id = add_sym(sym);
   global_object_add(sym_id, &regs[ra]);


### PR DESCRIPTION
* Replaced `GETARG_B` with `GETARG_Bx` on `OP_GETGLOBAL` according to opcode signature
* Replaced `GETARG_B` with `GETARG_Bx` on `OP_SETGLOBAL` according to opcode signature

Can not imagine case when it causes to fail with current bounds of globals array but think that it should be consistent.