### PR TITLE
Add constants support

### DIFF
--- a/src/global.c
+++ b/src/global.c
@@ -28,6 +28,20 @@ static int search_global_object(mrb_sym sym_id)
   return -1;
 }
 
+static int search_const(mrb_sym sym_id) {
+  int left = 0, right = MAX_CONST_COUNT-1;
+  while (left <= right) {
+    int mid = (left + right) / 2;
+    if ( static_const[mid].sym_id == sym_id ) return mid;
+    if ( static_const[mid].sym_id < sym_id ) {
+      right = mid - 1;
+    } else {
+      left = mid + 1;
+    }
+  }
+  return -1;
+}
+
 /* add */
 void global_object_add(mrb_sym sym_id, mrb_object *obj)
 {
@@ -43,6 +57,20 @@ void global_object_add(mrb_sym sym_id, mrb_object *obj)
   static_global[index].obj = *obj;
 }
 
+void const_add(mrb_sym sym_id, mrb_object *obj)
+{
+  int index = search_const(sym_id);
+  if( index == -1 ){
+    index = MAX_CONST_COUNT-1;
+    while(index > 0 && static_const[index].sym_id < sym_id ){
+      static_const[index] = static_const[index-1];
+      index--;
+    }
+  }
+  static_const[index].sym_id = sym_id;
+  static_const[index].obj = *obj;
+}
+
 /* get */
 mrb_object global_object_get(mrb_sym sym_id)
 {
@@ -51,6 +79,17 @@ mrb_object global_object_get(mrb_sym sym_id)
     return static_global[index].obj;
   } else {
     /* nil */
+    mrb_object obj;
+    obj.tt = MRB_TT_FALSE;
+    return obj;
+  }
+}
+
+mrb_object const_get(mrb_sym sym_id) {
+  int index = search_const(sym_id);
+  if (index >= 0){
+    return static_const[index].obj;
+  } else {
     mrb_object obj;
     obj.tt = MRB_TT_FALSE;
     return obj;

--- a/src/global.h
+++ b/src/global.h
@@ -20,15 +20,23 @@
 extern "C" {
 #endif
 
+#define OBJECT_WITH_SYMBOL\
+  mrb_sym sym_id;\
+  mrb_object obj
 
 typedef struct GLOBAL_OBJECT {
-  mrb_sym sym_id;
-  mrb_object obj;
+  OBJECT_WITH_SYMBOL;
 } mrb_globalobject;
+
+typedef struct CONST_OBJECT {
+  OBJECT_WITH_SYMBOL;
+} mrb_constobject;
 
 void global_object_add(mrb_sym sym_id, mrb_object *obj);
 mrb_object global_object_get(mrb_sym sym_id);
 
+void const_add(mrb_sym sym_id, mrb_object *obj);
+mrb_object const_get(mrb_sym sym_id);
 
 #ifdef __cplusplus
 }

--- a/src/load.c
+++ b/src/load.c
@@ -1,8 +1,12 @@
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
+#ifdef __MACH__ //to be sure that loader compiles with clang too
+#include <stdlib.h>
+#else
+#include <malloc.h>
+#endif
 #include "vm.h"
 #include "vm_config.h"
 #include "load.h"

--- a/src/load.c
+++ b/src/load.c
@@ -2,11 +2,6 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
-#ifdef __MACH__ //to be sure that loader compiles with clang too
-#include <stdlib.h>
-#else
-#include <malloc.h>
-#endif
 #include "vm.h"
 #include "vm_config.h"
 #include "load.h"

--- a/src/opcode.h
+++ b/src/opcode.h
@@ -55,6 +55,9 @@ enum OPCODE {
   OP_GETGLOBAL = 0x09,
   OP_SETGLOBAL = 0x0a,
 
+  OP_GETCONST = 0x11,
+  OP_SETCONST = 0x12,
+
   OP_JMP = 0x17,
   OP_JMPIF = 0x18,
   OP_JMPNOT = 0x19,

--- a/src/static.c
+++ b/src/static.c
@@ -21,6 +21,8 @@ mrb_class *static_pool_class;
 static mrb_proc static_proc[MAX_PROC_COUNT];
 mrb_proc *static_pool_proc;
 
+mrb_constobject static_const[MAX_CONST_COUNT];
+
 mrb_globalobject static_global[MAX_GLOBAL_OBJECT_SIZE];
 
 /* Class Tree */
@@ -73,6 +75,10 @@ void init_static(void)
   /* global objects */
   for( i=0 ; i<MAX_GLOBAL_OBJECT_SIZE ; i++ ){
     static_global[i].sym_id = -1;
+  }
+
+  for( i=0 ; i<MAX_CONST_COUNT; i++ ){
+    static_const[i].sym_id = -1;
   }
 
   /* symbol */

--- a/src/static.h
+++ b/src/static.h
@@ -51,6 +51,7 @@ extern mrb_class *static_class_fixnum;
 extern mrb_class *static_class_float;
 #endif
 
+extern mrb_constobject static_const[];
 /* Global Objects */
 extern mrb_globalobject static_global[];
 

--- a/src/vm.c
+++ b/src/vm.c
@@ -253,6 +253,49 @@ inline static int op_setglobal( mrb_vm *vm, uint32_t code, mrb_value *regs )
   return 0;
 }
 
+//================================================================
+/*!@brief
+  Execute GETCONST
+
+  R(A) := constget(Syms(Bx))
+
+  @param  vm    A pointer of VM.
+  @param  code  bytecode
+  @param  regs  vm->regs + vm->reg_top
+  @retval 0  No error.
+*/
+inline static int op_getconst( mrb_vm *vm, uint32_t code, mrb_value *regs )
+{
+  int ra = GETARG_A(code);
+  int rb = GETARG_Bx(code);
+  char *sym = find_irep_symbol(vm->pc_irep->ptr_to_sym, rb);
+  mrb_sym sym_id = add_sym(sym);
+  regs[ra] = const_get(sym_id);
+  return 0;
+}
+
+
+//================================================================
+/*!@brief
+  Execute SETCONST
+
+  constset(Syms(Bx),R(A))
+
+  @param  vm    A pointer of VM.
+  @param  code  bytecode
+  @param  regs  vm->regs + vm->reg_top
+  @retval 0  No error.
+*/
+
+inline static int op_setconst( mrb_vm *vm, uint32_t code, mrb_value *regs ) {
+  int ra = GETARG_A(code);
+  int rb = GETARG_Bx(code);
+  char *sym = find_irep_symbol(vm->pc_irep->ptr_to_sym, rb);
+  mrb_sym sym_id = add_sym(sym);
+  const_add(sym_id, &regs[ra]);
+  return 0;
+}
+
 
 //================================================================
 /*!@brief
@@ -1056,6 +1099,8 @@ int vm_run_step( mrb_vm *vm )
     case OP_LOADF:      ret = op_loadf     (vm, code, regs); break;
     case OP_GETGLOBAL:  ret = op_getglobal (vm, code, regs); break;
     case OP_SETGLOBAL:  ret = op_setglobal (vm, code, regs); break;
+    case OP_GETCONST:   ret = op_getconst  (vm, code, regs); break;
+    case OP_SETCONST:   ret = op_setconst  (vm, code, regs); break;
     case OP_JMP:        ret = op_jmp       (vm, code, regs); break;
     case OP_JMPIF:      ret = op_jmpif     (vm, code, regs); break;
     case OP_JMPNOT:     ret = op_jmpnot    (vm, code, regs); break;

--- a/src/vm_config.h
+++ b/src/vm_config.h
@@ -49,8 +49,8 @@
 /* maximum size of global objects */
 #define MAX_GLOBAL_OBJECT_SIZE 20
 
-
-
+/* maximum size of consts */
+#define MAX_CONST_COUNT 20
 
 /* Configure environment */
 /* 0: NOT USE */


### PR DESCRIPTION
* Added support for opcodes `OP_GETCONST` and `OP_SETCONST`
* Added global array `static_const` with `MAX_CONST_COUNT` defaults to 20 (as globals)

Tests:
* Tests for this feature are already in repo, `src/sample_ruby/variable_sample02.rb`, now it successes