### PR TITLE
Fixes #7: Changed type of code and ptr_to_sym in IREP struct

### DIFF
--- a/sample_c/Makefile
+++ b/sample_c/Makefile
@@ -7,7 +7,7 @@
 #  This file is distributed under BSD 3-Clause License.
 #
 
-CPPFLAGS = -g -I ../src
+CPPFLAGS = -g -I ../src -Wall -Wpointer-arith
 LDFLAGS = -L ../src
 LDLIBS = -lmrubyc
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -7,7 +7,7 @@
 #  This file is distributed under BSD 3-Clause License.
 #
 
-CFLAGS = -Wall -g # -DDEBUG
+CFLAGS = -Wall -Wpointer-arith -g # -DDEBUG
 
 COMMON_OBJ = class.o global.o load.o vm.o static.o value.o common.o symbol.o
 RUBY_LIBS = c_array.o c_numeric.o

--- a/src/load.c
+++ b/src/load.c
@@ -81,7 +81,7 @@ int load_irep(struct VM *vm, char **pos)
     p = (char *)( ( (unsigned long)p + 3 ) & ~3L );
 
     // code
-    irep->code = p;
+    irep->code = (uint8_t *)p;
     p += irep->ilen * 4;
 
     // pool
@@ -118,7 +118,7 @@ int load_irep(struct VM *vm, char **pos)
     }
 
     //  syms
-    irep->ptr_to_sym = p;
+    irep->ptr_to_sym = (uint8_t*)p;
     int slen = get_int_4(p);    p += 4;
     for( i=0 ; i<slen ; i++ ){
       int s = get_int_2(p);     p += 2;

--- a/src/vm.h
+++ b/src/vm.h
@@ -33,9 +33,9 @@ typedef struct IREP {
   int16_t unused;       //! unused flag
   struct IREP *next;         //! irep linked list
 
-  void *code;
+  uint8_t *code;
   mrb_object *ptr_to_pool;
-  void *ptr_to_sym;
+  uint8_t *ptr_to_sym;
 
   int16_t nlocals;
   int16_t nregs;


### PR DESCRIPTION
Type of `code` and `ptr_to_sym` was changed to avoid void-pointer arithmetics.