### PR TITLE
MRUBY_ROOT can be specified on auto_test.rb

### DIFF
--- a/auto_test/auto_test.rb
+++ b/auto_test/auto_test.rb
@@ -1,4 +1,4 @@
-#
+#!/usr/bin/env ruby
 #
 #
 
@@ -11,9 +11,11 @@ if ARGV.count == 0 then
   exit
 end
 
+mruby_path = ENV['MRUBY_ROOT']
+mruby_path = '../../mruby' unless mruby_path
 
-$mruby_exe = '../../mruby/bin/mruby'
-$mrbc_exe = '../../mruby/bin/mrbc'
+$mruby_exe = File.join(mruby_path, 'bin/mruby')
+$mrbc_exe = File.join(mruby_path, 'bin/mrbc')
 $mrubyc_exe = '../sample_c/mrubyc'
 
 unless File.exists?($mruby_exe) then


### PR DESCRIPTION
It is now possible to specify mruby's PATH in auto_test.rb.

## example
```bash
$ cd sample_ruby
$ MRUBY_ROOT=~/mruby ./auto_test.rb bool.rb
```