### PR TITLE
length of return value of sprintf is one byte longer than actual length

### DIFF
--- a/src/c_string.c
+++ b/src/c_string.c
@@ -537,7 +537,7 @@ static void c_sprintf(mrb_vm *vm, mrb_value v[], int argc)
   }
   mrbc_printf_end( &pf );
 
-  buflen = mrbc_printf_len( &pf ) + 1;
+  buflen = mrbc_printf_len( &pf );
   mrbc_realloc(vm, pf.buf, buflen);
 
   mrb_value value = mrbc_string_new_alloc( vm, pf.buf, buflen );


### PR DESCRIPTION
therefore, it causes a problem like this
```
value = sprintf('%5.2f', 12.34567) #=> "12.34" (this is good for now, but...)
value.size #=> 6 (we expect 5!)
str = "start" + value + "end" # (str will be "start12.34\0end" in memory)
puts str #=> "str12.34"
```