### PR TITLE
Add hal for ESP32

### DIFF
--- a/src/hal_esp32/hal.c
+++ b/src/hal_esp32/hal.c
@@ -1,0 +1,112 @@
+/*! @file
+  @brief
+  Realtime multitask monitor for mruby/c
+  Hardware abstraction layer
+        for ESP32
+
+  <pre>
+  Copyright (C) 2016-2018 Kyushu Institute of Technology.
+  Copyright (C) 2016-2018 Shimane IT Open-Innovation Center.
+
+  This file is distributed under BSD 3-Clause License.
+  </pre>
+*/
+
+/***** Feature test switches ************************************************/
+/***** System headers *******************************************************/
+#include <stdio.h>
+#include "esp_types.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "freertos/queue.h"
+#include "soc/timer_group_struct.h"
+#include "driver/periph_ctrl.h"
+#include "driver/timer.h"
+
+
+/***** Local headers ********************************************************/
+#include "hal.h"
+
+
+/***** Constat values *******************************************************/
+#define TIMER_DIVIDER 80
+
+/***** Macros ***************************************************************/
+/***** Typedefs *************************************************************/
+/***** Function prototypes **************************************************/
+/***** Local variables ******************************************************/
+static portMUX_TYPE mux = portMUX_INITIALIZER_UNLOCKED;
+
+
+/***** Global variables *****************************************************/
+/***** Signal catching functions ********************************************/
+/***** Local functions ******************************************************/
+#ifndef MRBC_NO_TIMER
+//================================================================
+/*!@brief
+  Timer ISR function
+
+*/
+static void on_timer(void *arg)
+{
+    TIMERG0.int_clr_timers.t0 = 1;
+    TIMERG0.hw_timer[TIMER_0].config.alarm_en = TIMER_ALARM_EN;
+    mrbc_tick();
+}
+
+
+#endif
+
+
+/***** Global functions *****************************************************/
+#ifndef MRBC_NO_TIMER
+
+//================================================================
+/*!@brief
+  initialize
+
+*/
+void hal_init(void)
+{
+  timer_config_t config;
+
+  config.divider = TIMER_DIVIDER;
+  config.counter_dir = TIMER_COUNT_UP;
+  config.counter_en = TIMER_PAUSE;
+  config.alarm_en = TIMER_ALARM_EN;
+  config.intr_type = TIMER_INTR_LEVEL;
+  config.auto_reload = TIMER_AUTORELOAD_EN;
+
+  timer_init(TIMER_GROUP_0, TIMER_0, &config);
+  timer_set_counter_value(TIMER_GROUP_0, TIMER_0, 0x00000000ULL);
+  timer_set_alarm_value(TIMER_GROUP_0, TIMER_0, 1000); /* 1ms */
+  timer_enable_intr(TIMER_GROUP_0, TIMER_0);
+  timer_isr_register(TIMER_GROUP_0, TIMER_0, on_timer, NULL, 0, NULL);
+
+  timer_start(TIMER_GROUP_0, TIMER_0);
+}
+
+
+//================================================================
+/*!@brief
+  enable interrupt
+
+*/
+void hal_enable_irq(void)
+{
+  taskEXIT_CRITICAL(&mux);
+}
+
+
+//================================================================
+/*!@brief
+  disable interrupt
+
+*/
+void hal_disable_irq(void)
+{
+  taskENTER_CRITICAL(&mux);
+}
+
+
+#endif /* ifndef MRBC_NO_TIMER */

--- a/src/hal_esp32/hal.h
+++ b/src/hal_esp32/hal.h
@@ -1,0 +1,87 @@
+/*! @file
+  @brief
+  Realtime multitask monitor for mruby/c
+  Hardware abstraction layer
+        for ESP32
+
+  <pre>
+  Copyright (C) 2016-2018 Kyushu Institute of Technology.
+  Copyright (C) 2016-2018 Shimane IT Open-Innovation Center.
+
+  This file is distributed under BSD 3-Clause License.
+  </pre>
+*/
+
+#ifndef MRBC_SRC_HAL_H_
+#define MRBC_SRC_HAL_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/***** Feature test switches ************************************************/
+/***** System headers *******************************************************/
+#include <unistd.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
+
+/***** Local headers ********************************************************/
+/***** Constant values ******************************************************/
+/***** Macros ***************************************************************/
+#ifndef MRBC_SCHEDULER_EXIT
+#define MRBC_SCHEDULER_EXIT 1
+#endif
+
+
+/***** Typedefs *************************************************************/
+/***** Global variables *****************************************************/
+/***** Function prototypes **************************************************/
+void mrbc_tick(void);
+
+#ifndef MRBC_NO_TIMER
+void hal_init(void);
+void hal_enable_irq(void);
+void hal_disable_irq(void);
+# define hal_idle_cpu()    vTaskDelay(1000/portTICK_PERIOD_MS)
+
+#else // MRBC_NO_TIMER
+# define hal_init()        ((void)0)
+# define hal_enable_irq()  ((void)0)
+# define hal_disable_irq() ((void)0)
+# define hal_idle_cpu()    (vTaskDelay(1/portTICK_PERIOD_MS), mrbc_tick())
+
+#endif
+
+
+/***** Inline functions *****************************************************/
+
+//================================================================
+/*!@brief
+  Write
+
+  @param  fd    dummy, but 1.
+  @param  buf   pointer of buffer.
+  @param  nbytes        output byte length.
+*/
+inline static int hal_write(int fd, const void *buf, int nbytes)
+{
+  return write(1, buf, nbytes);
+}
+
+//================================================================
+/*!@brief
+  Flush write baffer
+
+  @param  fd    dummy, but 1.
+*/
+inline static int hal_flush(int fd)
+{
+  return fsync(1);
+}
+
+
+#ifdef __cplusplus
+}
+#endif
+#endif // ifndef MRBC_HAL_H_


### PR DESCRIPTION
I implemented HAL for the ESP32 microcontroller.
It's confirmed that `main_concurrent.c` code works correctly in both cases of `MRBC_NO_TIMER` value.

Also, I created a application template for running mruby/c on ESP32. 

+  https://github.com/mruby-esp32/mrubyc-esp32

Regards,