### PR TITLE
Fix No method error about initialize

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -441,6 +441,12 @@ static void c_object_new(mrb_vm *vm, mrb_value v[], int argc)
   mrb_value new_obj = mrbc_instance_new(vm, v->cls, 0);
 
   char syms[]="______initialize";
+  mrb_sym sym_id = str_to_symid(&syms[6]);
+  mrb_proc *m = find_method(vm, v[0], sym_id);
+  if( m==0 ){
+    SET_RETURN(new_obj);
+    return;
+  }
   uint32_to_bin( 1,(uint8_t*)&syms[0]);
   uint16_to_bin(10,(uint8_t*)&syms[4]);
 


### PR DESCRIPTION
## Detail of error condition
Current version shows an error like "No method. vtype=20 method='initialize'" when we run the mrubyc_myclass sample.

## Reason of the error
This error comes from my last pull request #52 . It does call an initialize method even if the method is not defined.

## Detail of fix
Skip to call an initialize method if the method is not defined.