### PR TITLE
fix out of memory error in main_sample.c

### DIFF
--- a/sample_c/main_sample.c
+++ b/sample_c/main_sample.c
@@ -8,7 +8,7 @@
 
 #include "sample01.c"
 
-#define MEMORY_SIZE (1024*10)
+#define MEMORY_SIZE (1024*30)
 static uint8_t memory_pool[MEMORY_SIZE];
 
 int main(void)


### PR DESCRIPTION
# Detail of error condition
mrubyc_sample shows
```
Fatal error: Out of memory.
VM open Error
```
# Reason of the error
10KB is not enough to run the sample code in  sample01.c.

# Detail of fix
Increase memory size from 10KB to 30KB according to other samples.