### PR TITLE
fix esp32 hal_idle_cpu()

### DIFF
--- a/src/hal_esp32/hal.h
+++ b/src/hal_esp32/hal.h
@@ -42,7 +42,7 @@ void mrbc_tick(void);
 void hal_init(void);
 void hal_enable_irq(void);
 void hal_disable_irq(void);
-# define hal_idle_cpu()    vTaskDelay(1000/portTICK_PERIOD_MS)
+# define hal_idle_cpu()    float tickUnit = 1/portTICK_PERIOD_MS;vTaskDelay(tickUnit < 1 ? 1 : tickUnit)
 
 #else // MRBC_NO_TIMER
 # define hal_init()        ((void)0)


### PR DESCRIPTION
## environments
- ESP-WROOM-32
- esp-idf release/v3.1
- build on Linux Mint 18.2

## the issue
current code of `# define hal_idle_cpu()    vTaskDelay(1000/portTICK_PERIOD_MS)` seems to be a port from POSIX's code:
```
# define hal_idle_cpu()    sleep(1) // maybe interrupt by SIGINT
```

POSIX version's hal_idle_cpu works fine as its comment says, will be interrupted before sleep 1 second.

but in esp32 version, `sleep_ms(1)` calls `vTaskDelay(1000/portTICK_PERIOD_MS)` then the task stops 1 second.

## solution

amending from `1000` to `1` will resolve `sleep_ms` bug:
```
`# define hal_idle_cpu()    vTaskDelay(1/portTICK_PERIOD_MS)`
```

but it has another problem with RTOS's Watchdog warning.
for example, `portTICK_PERIOD_MS` was `10` in my env, it depends on CPU clock though.
therefore vTaskDelay(); does nothing regarding `1/portTICK_PERIOD_MS` as zero, then Watchdog will warn that it can't work as RTOS expects.
(whether it warns or not depends on the implementation of our application)

so my suggestion is that vTaskDelay(); should always delay the task at least ONE tick.

my solution removed all the warnings from my app.