### PR TITLE
bugfix a compile error about struct initialization on Arduino IDE

### DIFF
--- a/src/console.h
+++ b/src/console.h
@@ -27,21 +27,21 @@ extern "C" {
 //================================================================
 /*! printf tiny (mruby/c) version data container.
 */
+struct RPrintfFormat {
+  char type;				//!< format char. (e.g. 'd','f','x'...)
+  unsigned int flag_plus : 1;
+  unsigned int flag_minus : 1;
+  unsigned int flag_space : 1;
+  unsigned int flag_zero : 1;
+  int width;				//!< display width. (e.g. %10d as 10)
+  int precision;			//!< precision (e.g. %5.2f as 2)
+};
 typedef struct RPrintf {
   char *buf;		//!< output buffer.
   const char *buf_end;	//!< output buffer end point.
   char *p;		//!< output buffer write point.
   const char *fstr;	//!< format string. (e.g. "%d %03x")
-
-  struct RPrintfFormat {
-    char type;				//!< format char. (e.g. 'd','f','x'...)
-    unsigned int flag_plus : 1;
-    unsigned int flag_minus : 1;
-    unsigned int flag_space : 1;
-    unsigned int flag_zero : 1;
-    int width;				//!< display width. (e.g. %10d as 10)
-    int precision;			//!< precision (e.g. %5.2f as 2)
-  } fmt;
+  struct RPrintfFormat fmt;
 } mrbc_printf;
 
 


### PR DESCRIPTION
## Detail of error condition

Following error happens in case of compiling source code on Arduino IDE.
```
console.h:94:37: error: too many initializers for 'mrbc_printf_init(mrb_printf*, char*, int, const char*)::RPrintfFormat'
   pf->fmt = (struct RPrintfFormat){0};
                                     ^
```

## Reason of the error
Arduino IDE use "g++" even if the source code is "*.c" file.
In that case, the inner struct which is defined in a top struct cannot be referred out of the top struct.

## Detail of fix
Move the definition of the inner struct to out of the top struct.