### PR TITLE
Add PlatformIO support

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,28 @@
+{
+  "name": "mruby/c",
+  "repository":
+  {
+    "type": "git",
+    "url": "https://github.com/foo/bar.git"
+  },
+  "license": "BSD-3-Clause",
+  "examples": [
+    "sample_c/*.c"
+  ],
+  "build": {
+    "srcFilter": [
+      "+<*>",
+      "-<hal_*>",
+      "+<hal>"
+    ],
+    "extraScript": "platformio.py"
+  },
+  "frameworks": "*",
+  "platforms": [
+    "espressif32",
+    "native",
+    "linux_arm",
+    "linux_i686",
+    "linux_x86_64"
+  ]
+}

--- a/library.json
+++ b/library.json
@@ -3,7 +3,7 @@
   "repository":
   {
     "type": "git",
-    "url": "https://github.com/foo/bar.git"
+    "url": "https://github.com/mrubyc/mrubyc.git"
   },
   "license": "BSD-3-Clause",
   "examples": [

--- a/platformio.py
+++ b/platformio.py
@@ -1,0 +1,19 @@
+Import('env')
+from os.path import join, realpath, islink, abspath
+from os import symlink, unlink
+
+# Initialize
+hal_symbol = abspath(join("src", "hal"))
+unlink(hal_symbol)
+
+for item in env.get("CPPDEFINES", []):
+    # Setup HAL
+    if isinstance(item, tuple) and item[0] == "HAL":
+        src = realpath(join("src", "hal_" + item[1].lower()))
+        symlink(src, hal_symbol)
+        break
+
+# Default HAL=posix
+if not islink(hal_symbol):
+    src = realpath(join("src", "hal_posix"))
+    symlink(src, hal_symbol)

--- a/platformio.py
+++ b/platformio.py
@@ -4,7 +4,8 @@ from os import symlink, unlink
 
 # Initialize
 hal_symbol = abspath(join("src", "hal"))
-unlink(hal_symbol)
+if islink(hal_symbol):
+    unlink(hal_symbol)
 
 for item in env.get("CPPDEFINES", []):
     # Setup HAL


### PR DESCRIPTION
I use [PlatformIO](https://platformio.org/) to compile firmware to `ESP32 DevKitC` but I have to manual setup mruby/c to let it can be compiled correctly.

Depend on PlatformIO's document, I add some configure can automatically set up correctly HAL to help me compile it correctly.

---

Below is my step to compile ESP32 firmware use PlatformIO and upload it.

```
# Install PlatformIO on macOS
brew install platformio

# Initialize new project
mkdir esp32
cd esp32
pio init -b esp32dev # ESP32 DevKitC default configure
```

Edit `platformio.ini` to adjust configure to support mruby/c

```diff
[env:esp32dev]
platform = espressif32
board = esp32dev
- framework = arduino
+ framework = espidf
+ build_flags = -DHAL=esp32
```

And clone mruby/c into `lib/` to add mruby/c
```
git clone git@github.com:mrubyc/mrubyc.git lib/mrubyc
```

Then add some mruby/c code to `src/main.c` and compile it

```
pio run
# `pio run -t upload` to upload it
```

---

If this PR is accepted, we can [register](https://docs.platformio.org/en/latest/librarymanager/creating.html#register) it, and others can simple add depends for their PlatformIO without any configure.