### PR TITLE
Fix memory leak when call the block.

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -1199,7 +1199,6 @@ static inline int op_blkpush( mrbc_vm *vm, mrbc_value *regs )
     }
     stack = callinfo->current_regs + 1 - offset;
   }
-  mrbc_dup( stack );
   regs[a] = *stack;
 
   return 0;


### PR DESCRIPTION
Fixed a bug that the memory area of ``mrbc_proc`` continued to increase when calling blocks.

## sample code

```ruby
GGA = "$GPGGA,,,,,,0,00,99.99,,,,,,*48"

def func
  i = 0
  while true
    items = GGA.split(',')
    print "#{i}: "
    items.each {|item|
      print item + ','
    }
    print "\n"

    i += 1
    break if i > 10000
  end
end

func
```

## expected

```
$ sample_c/mrubyc memcheck.mrb
0: $GPGGA,,,,,,0,00,99.99,,,,,,*48,
1: $GPGGA,,,,,,0,00,99.99,,,,,,*48,
2: $GPGGA,,,,,,0,00,99.99,,,,,,*48,
3: $GPGGA,,,,,,0,00,99.99,,,,,,*48,
:
:
:
9997: $GPGGA,,,,,,0,00,99.99,,,,,,*48,
9998: $GPGGA,,,,,,0,00,99.99,,,,,,*48,
9999: $GPGGA,,,,,,0,00,99.99,,,,,,*48,
10000: $GPGGA,,,,,,0,00,99.99,,,,,,*48,
```

## actual

```
0: $GPGGA,,,,,,0,00,99.99,,,,,,*48,
1: $GPGGA,,,,,,0,00,99.99,,,,,,*48,
2: $GPGGA,,,,,,0,00,99.99,,,,,,*48,
3: $GPGGA,,,,,,0,00,99.99,,,,,,*48,
:
:
:
339: $GPGGA,,,,,,0,00,99.99,,,,,,*48,
340: $GPGGA,,,,,,0,00,99.99,,,,,,*48,
Fatal error: Out of memory.
Fatal error: Out of memory.
:
:
:
Fatal error: Out of memory.
Fatal error: Out of memory.
Segmentation fault: 11
```
