### PR TITLE
Improve test

### DIFF
--- a/.mrubycconfig
+++ b/.mrubycconfig
@@ -5,4 +5,4 @@ mrubyc_src_dir: src
 mrubyc_mrblib_dir: mrblib
 mruby_lib_dir: test
 mruby_version: mruby-2.0.1
-cruby_version: 2.6.3
+cruby_version: 2.7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,5 @@ before_script:
   - RBENV_VERSION=$CRUBY_VERSION bundle install
 
 script:
-  - RBENV_VERSION=$CRUBY_VERSION CFLAGS=-DMAX_SYMBOLS_COUNT=500 bundle exec mrubyc-test --every=5
+  - RBENV_VERSION=$CRUBY_VERSION CFLAGS="-DMRBC_USE_MATH=1 -DMAX_SYMBOLS_COUNT=500" bundle exec mrubyc-test --every=100
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem "mrubyc-test", "~> 0.5.0"
+gem "mrubyc-test", "~> 0.5.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.4.1)
+    activesupport (5.2.4.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -10,7 +10,7 @@ GEM
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     minitest (5.14.0)
-    mrubyc-test (0.5.0)
+    mrubyc-test (0.5.1)
       activesupport (~> 5.2)
       rufo (~> 0.12)
       thor (~> 1.0)
@@ -24,7 +24,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  mrubyc-test (~> 0.5.0)
+  mrubyc-test (~> 0.5.1)
 
 BUNDLED WITH
    2.1.4

--- a/test/tmp/main.c
+++ b/test/tmp/main.c
@@ -4,7 +4,7 @@
 #include "models.c"
 #include "test.c"
 
-#define MEMORY_SIZE (1024*64)-1
+#define MEMORY_SIZE (1024*640)-1
 static uint8_t my_memory_pool[MEMORY_SIZE];
 
 int exit_code;


### PR DESCRIPTION
- bump up mrubyc-test to 0.5.1
  - it eliminated MRUBYC_DEBUG option (using NDEBUG in production build instead)
- increase MEMORY_SIZE so that test can be done by executing once
  - and `--every=100`
- add MRBC_USE_MATH=1 option to test
- bump up CRuby to 2.7.0