### PR TITLE
test setup for mrubyc3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ test:
 	docker run --mount type=bind,src=${PWD}/,dst=/root/mrubyc \
 	  -e CFLAGS="-DMRBC_USE_MATH=1 -DMAX_SYMBOLS_COUNT=500 $(CFLAGS)" \
 	  mrubyc/mrubyc-test bundle exec mrubyc-test \
-	  --every=100 \
+	  --every=10 \
 	  --mrbc-path=/root/mruby/build/host/bin/mrbc \
 	  $(file)
 

--- a/mrblib/global.rb
+++ b/mrblib/global.rb
@@ -8,5 +8,5 @@
 #
 
 RUBY_VERSION = "1.9"
-MRUBY_VERSION = "2.1.1"
+MRUBY_VERSION = "3.0.0-preview"
 MRUBYC_VERSION = "3.0"


### PR DESCRIPTION
- `mrubyc-test --every=100` -> `10` to avoid `too big operand error` in mruby/3.0.0-preview
- switch mruby tag into 3.0.0-preview