### PR TITLE
Improve test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,36 @@
-from ruby:2.7.2-slim
+from ruby:3.0.0-slim
 
 RUN apt update && apt -y upgrade
-RUN apt install -y bison make git gcc gcc-arm-linux-gnueabi qemu qemu-kvm qemu-system-arm
+RUN apt install -y \
+  bison \
+  gcc \
+  gcc-arm-linux-gnueabi \
+  git \
+  make \
+  qemu \
+  qemu-kvm \
+  qemu-system-arm
 
 RUN gem update --system
 
-RUN git clone https://github.com/mruby/mruby /root/mruby
-ARG MRUBY_TAG
-RUN cd /root/mruby; git checkout $MRUBY_TAG; make
+RUN useradd -m -u 1000 mrubyc
+RUN mkdir /work && chown mrubyc /work
 
-VOLUME /root/mrubyc
-COPY Gemfile /root/mrubyc/
-COPY Gemfile.lock /root/mrubyc/
-WORKDIR /root/mrubyc
+USER mrubyc
+
+VOLUME /work/mrubyc
+COPY --chown=mrubyc Gemfile /work/mrubyc/
+COPY --chown=mrubyc Gemfile.lock /work/mrubyc/
+
+USER root
+WORKDIR /work/mrubyc
 RUN bundle install
+
+USER mrubyc
 ENV CFLAGS="-DMRBC_USE_MATH=1 -DMAX_SYMBOLS_COUNT=500"
-CMD ["bundle", "exec", "mrubyc-test", "-e", "100", "-p", "/root/mruby/build/host/bin/mrbc"]
+
+RUN git clone https://github.com/mruby/mruby /work/mruby
+ARG MRUBY_TAG
+RUN cd /work/mruby; git fetch --prune; git checkout $MRUBY_TAG; make clean && make
+
+CMD ["bundle", "exec", "mrubyc-test", "-e", "10", "-p", "/work/mruby/build/host/bin/mrbc"]

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem "mrubyc-test", "~> 0.6"
+gem "mrubyc-test", "~> 0.6.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,32 +1,31 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.3.4)
+    activesupport (6.1.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
-      zeitwerk (~> 2.2, >= 2.2.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
     concurrent-ruby (1.1.7)
-    i18n (1.8.5)
+    i18n (1.8.7)
       concurrent-ruby (~> 1.0)
-    minitest (5.14.2)
-    mrubyc-test (0.6.0)
+    minitest (5.14.3)
+    mrubyc-test (0.6.1)
       activesupport (~> 6.0)
       rufo (~> 0.12)
       thor (~> 1.0)
     rufo (0.12.0)
     thor (1.0.1)
-    thread_safe (0.3.6)
-    tzinfo (1.2.7)
-      thread_safe (~> 0.1)
-    zeitwerk (2.4.0)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
+    zeitwerk (2.4.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  mrubyc-test (~> 0.6)
+  mrubyc-test (~> 0.6.1)
 
 BUNDLED WITH
-   2.1.4
+   2.2.5


### PR DESCRIPTION
- Bump up mrubyc-test which:
  - is confirmed to run with Ruby 3.0.0
  - adds `-O0 -g3` to make debug easier
- Dockerfile
  - uses ruby:3.0.0-slim image
  - makes cache working better
- Makefile
  - includes check_tag target which detects change of MRUBY_VERSION
    in mrblib/global.rb and automatically invokes `make setup_test`
