### PR TITLE
Object#p should return args of the method

### DIFF
--- a/src/c_object.c
+++ b/src/c_object.c
@@ -229,6 +229,24 @@ static void c_object_p(struct VM *vm, mrbc_value v[], int argc)
     mrbc_p_sub( &v[i] );
     console_putchar('\n');
   }
+  if (argc == 0) {
+    SET_NIL_RETURN();
+  } else if (argc == 1) {
+    SET_RETURN(v[1]);
+  } else {
+    mrbc_value value = mrbc_array_new(vm, argc);
+    if( value.array == NULL ) {
+      SET_NIL_RETURN();  // ENOMEM
+    } else {
+      for ( i = 1; i <= argc; i++ ) {
+        mrbc_incref( &v[i] );
+        value.array->data[i-1] = v[i];
+      }
+      value.array->n_stored = argc;
+      mrbc_incref(&value);
+      SET_RETURN(value);
+    }
+  }
 }
 
 

--- a/test/object_test.rb
+++ b/test/object_test.rb
@@ -15,4 +15,22 @@ class ObjectTest < MrubycTestCase
     assert_equal false, false.nil?
     assert_equal nil, puts("Hello World!")
   end
+
+  description 'Object#p method without arg'
+  def p_returns_args_0
+    a = p
+    assert_equal nil, a
+  end
+
+  description 'Object#p method with an arg'
+  def p_returns_args_1
+    a = p 1
+    assert_equal 1, a
+  end
+
+  description 'Object#p method with multiple args'
+  def p_returns_args_m
+    a = p 1, "hello", :hey
+    assert_equal [1, "hello", :hey], a
+  end
 end


### PR DESCRIPTION
Reference: https://docs.ruby-lang.org/ja/latest/method/Kernel/m/p.html

## Actual
```
p 1
=> #<Object:66da8850>
```

## Expected
```
p 1
=> 1
```

Please see `test/object_test.rb` for more cases.