### PR TITLE
Add support for array's lacking part

### DIFF
--- a/src/c_array.c
+++ b/src/c_array.c
@@ -676,7 +676,7 @@ static void c_array_set(struct VM *vm, mrbc_value v[], int argc)
     // just ignore length
     if ( start >= size ) {
       mrbc_array_set(v, start, &v[3]);	// raise? IndexError or ENOMEM
-      v[2].tt = MRBC_TT_EMPTY;
+      v[3].tt = MRBC_TT_EMPTY;
       return;
     }
 
@@ -684,7 +684,7 @@ static void c_array_set(struct VM *vm, mrbc_value v[], int argc)
     // just replace
     if ( start < size && len == 1 ) {
       mrbc_array_set(v, start, &v[3]);	// raise? IndexError or ENOMEM
-      v[2].tt = MRBC_TT_EMPTY;
+      v[3].tt = MRBC_TT_EMPTY;
       return;
     }
 
@@ -692,7 +692,7 @@ static void c_array_set(struct VM *vm, mrbc_value v[], int argc)
     // just insert
     if ( start < size && len == 0 ) {
       mrbc_array_insert(v, start, &v[3]);	// raise? IndexError or ENOMEM
-      v[2].tt = MRBC_TT_EMPTY;
+      v[3].tt = MRBC_TT_EMPTY;
       return;
     } 
     
@@ -701,7 +701,7 @@ static void c_array_set(struct VM *vm, mrbc_value v[], int argc)
       mrbc_array_set(v, start, &v[3]);	// raise? IndexError or ENOMEM
       v->array->n_stored = start + 1;
 
-      v[2].tt = MRBC_TT_EMPTY;
+      v[3].tt = MRBC_TT_EMPTY;
       return;
 
     } else {
@@ -711,7 +711,7 @@ static void c_array_set(struct VM *vm, mrbc_value v[], int argc)
       memmove(p+start+1, p+start+len, sizeof(mrbc_value) * (size-start-len));
       v->array->n_stored -= len-1;
 
-      v[2].tt = MRBC_TT_EMPTY;
+      v[3].tt = MRBC_TT_EMPTY;
       return;
     }
 

--- a/src/c_array.h
+++ b/src/c_array.h
@@ -44,7 +44,7 @@ mrbc_value mrbc_array_get(const mrbc_value *ary, int idx);
 int mrbc_array_push(mrbc_value *ary, mrbc_value *set_val);
 mrbc_value mrbc_array_pop(struct VM *vm, mrbc_value *ary, uint16_t len);
 int mrbc_array_unshift(mrbc_value *ary, mrbc_value *set_val);
-mrbc_value mrbc_array_shift(mrbc_value *ary);
+mrbc_value mrbc_array_shift(struct VM *vm, mrbc_value *ary, uint16_t len );
 int mrbc_array_insert(mrbc_value *ary, int idx, mrbc_value *set_val);
 mrbc_value mrbc_array_remove(mrbc_value *ary, int idx);
 void mrbc_array_clear(mrbc_value *ary);

--- a/src/c_array.h
+++ b/src/c_array.h
@@ -42,7 +42,7 @@ int mrbc_array_resize(mrbc_value *ary, int size);
 int mrbc_array_set(mrbc_value *ary, int idx, mrbc_value *set_val);
 mrbc_value mrbc_array_get(const mrbc_value *ary, int idx);
 int mrbc_array_push(mrbc_value *ary, mrbc_value *set_val);
-mrbc_value mrbc_array_pop(mrbc_value *ary);
+mrbc_value mrbc_array_pop(struct VM *vm, mrbc_value *ary, uint16_t len);
 int mrbc_array_unshift(mrbc_value *ary, mrbc_value *set_val);
 mrbc_value mrbc_array_shift(mrbc_value *ary);
 int mrbc_array_insert(mrbc_value *ary, int idx, mrbc_value *set_val);

--- a/test/array_test.rb
+++ b/test/array_test.rb
@@ -66,6 +66,17 @@ class ArrayTest < MrubycTestCase
     assert_equal [99,88,nil,77], a
     a[-2] = 66
     assert_equal [99,88,66,77], a
+
+    assert_equal 44, a[6,50] = 44
+    assert_equal [99,88,66,77,nil,nil,44], a
+    a[2,1] = 77  
+    assert_equal [99,88,77,77,nil,nil,44], a
+    a[3,0] = 66
+    assert_equal [99,88,77,66,77,nil,nil,44], a
+    a[4,3] = 55
+    assert_equal [99,88,77,66,55,44], a
+    a[4,10] = 44
+    assert_equal [99,88,77,66,44], a
   end
 
   description "getter"

--- a/test/array_test.rb
+++ b/test/array_test.rb
@@ -164,6 +164,12 @@ class ArrayTest < MrubycTestCase
     assert_equal [], a
     assert_equal nil, a.shift()
     assert_equal [], a
+
+    a = [1,2,3,4]
+    assert_equal [1,2,3], a.shift(3)
+    assert_equal [4], a
+    assert_equal [4], a.shift(2)
+    assert_equal [], a
   end
 
   description "dup"

--- a/test/array_test.rb
+++ b/test/array_test.rb
@@ -139,6 +139,12 @@ class ArrayTest < MrubycTestCase
     assert_equal nil, a.pop()
     assert_equal [], a
 
+    a = [1,2,3,4]
+    assert_equal [2,3,4], a.pop(3)
+    assert_equal [1], a
+    assert_equal [1], a.pop(2)
+    assert_equal [], a
+
     a = []
     assert_equal [1], a << 1
     assert_equal [1,2], a << 2


### PR DESCRIPTION
Theses commits implement the "not implemented" parts currently in `c_array.c`, and I add tests for them too.
1. array.pop(n)
2. array.shift(n)
3. array[start,length] = xx

The test behaviors are consistent with `ruby 2.7.2` and `ruby 3.1.0` at least, I verified it by a manual test.

And I use `mrubyc-test` test them successfully on my machine (Linux x64).

But honestly, I'm not familiar with the `reference counting`, so it may have bugs though passing the tests.  So maybe a careful review on this is needed. Thank you. :)