### PR TITLE
OP_DEF should return Symbol of the method name

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -2490,6 +2490,8 @@ static inline void op_def( mrbc_vm *vm, mrbc_value *regs EXT )
       break;
     }
   }
+
+  mrbc_set_symbol(&regs[a], sym_id);
 }
 
 

--- a/test/def_test.rb
+++ b/test/def_test.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class DefTest < MrubycTestCase
+  description "OP_DEF should return the symbol of the method name"
+  METHOD_NAME_SYM = def op_def_return
+    assert_equal(:op_def_return, METHOD_NAME_SYM)
+  end
+end


### PR DESCRIPTION
mruby-compiler 3.0 used to produce `OP_LOADSYM` after `OP_DEF` to return the Symbol of the method name which was just defined.

As of mruby 3.1, mrbc no longer produces `OP_LOADSYM`.
Instead, the VM has to push the Symbol to reg[a] in `OP_DEF`.

See https://github.com/mruby/mruby/commit/d9a8981c26829aae0908244c3728f17e06a88ee2