### PR TITLE
mrbc_raise() should create len of message

### DIFF
--- a/src/error.c
+++ b/src/error.c
@@ -146,9 +146,8 @@ void mrbc_exception_delete(mrbc_value *value)
 void mrbc_raise( struct VM *vm, struct RClass *exc_cls, const char *msg )
 {
   if( vm ) {
-    vm->exception = mrbc_exception_new( vm, exc_cls ? exc_cls : MRBC_CLASS(RuntimeError), msg, 0 );
+    vm->exception = mrbc_exception_new( vm, exc_cls ? exc_cls : MRBC_CLASS(RuntimeError), msg, strlen(msg) );
     vm->flag_preemption = 2;
-
   } else {
     mrbc_printf("Exception: %s (%s)\n", msg ? msg : mrbc_symid_to_str(exc_cls->sym_id), mrbc_symid_to_str(exc_cls->sym_id));
   }

--- a/test/exception_test.rb
+++ b/test/exception_test.rb
@@ -60,4 +60,12 @@ class ExceptionTest < MrubycTestCase
     assert(!bad)
   end
 
+  def test_e_message
+    begin
+      String.new("1", "2")
+    rescue => e
+      assert_equal "wrong number of arguments (expected 0..1)", e.message
+    end
+  end
+
 end


### PR DESCRIPTION
## Example script
```ruby
def my_method(v)  # accepts only one parameter
end

begin
  my_method(1, 2)  # mistakenly passes two arguments
rescue => e
  puts e.class
  puts e.message
end
```

## Actual
```
ArgumentError

```

(no e.message printed)

## Expected
```
ArgumentError
wrong number of arguments.
```

