### PR TITLE
[backport] #140 Fix e.message

### DIFF
--- a/src/error.c
+++ b/src/error.c
@@ -139,14 +139,17 @@ void mrbc_exception_delete(mrbc_value *value)
 /*! raise exception
 
   @param  vm		pointer to VM.
-  @param  exc_cls	pointer to Exception class.
-  @param  msg		message.
+  @param  exc_cls	pointer to Exception class or NULL.
+  @param  msg		message or NULL.
   @note	(usage) mrbc_raise(vm, MRBC_CLASS(TypeError), "message here.");
 */
 void mrbc_raise( struct VM *vm, struct RClass *exc_cls, const char *msg )
 {
   if( vm ) {
-    vm->exception = mrbc_exception_new( vm, exc_cls ? exc_cls : MRBC_CLASS(RuntimeError), msg, 0 );
+    struct RClass *cls = exc_cls ? exc_cls : MRBC_CLASS(RuntimeError);
+    const char msg_len = msg ? strlen(msg) : 0;
+
+    vm->exception = mrbc_exception_new( vm, cls, msg, msg_len );
     vm->flag_preemption = 2;
 
   } else {

--- a/test/exception_test.rb
+++ b/test/exception_test.rb
@@ -60,4 +60,12 @@ class ExceptionTest < MrubycTestCase
     assert(!bad)
   end
 
+  def test_e_message
+    begin
+      String.new("1", "2")
+    rescue => e
+      assert_equal "wrong number of arguments (expected 0..1)", e.message
+    end
+  end
+
 end


### PR DESCRIPTION
#140
https://github.com/mrubyc/mrubyc/commit/49d2f8c592a36a1f70abacb7a6e7c52bc75b2ce7

- To make `e.message` (where e is an instance of an exception) work