### PR TITLE
Array#& and Array#|

### DIFF
--- a/src/_autogen_class_array.h
+++ b/src/_autogen_class_array.h
@@ -3,6 +3,7 @@
 
 /*===== Array class =====*/
 static const mrbc_sym method_symbols_Array[] = {
+  MRBC_SYM(AND),
   MRBC_SYM(PLUS),
   MRBC_SYM(LT_LT),
   MRBC_SYM(BL_BR),
@@ -35,9 +36,11 @@ static const mrbc_sym method_symbols_Array[] = {
   MRBC_SYM(to_s),
 #endif
   MRBC_SYM(unshift),
+  MRBC_SYM(OR),
 };
 
 static const mrbc_func_t method_functions_Array[] = {
+  c_array_and,
   c_array_add,
   c_array_push,
   c_array_get,
@@ -70,6 +73,7 @@ static const mrbc_func_t method_functions_Array[] = {
   c_array_inspect,
 #endif
   c_array_unshift,
+  c_array_or,
 };
 
 struct RBuiltinClass mrbc_class_Array = {

--- a/src/c_array.c
+++ b/src/c_array.c
@@ -68,6 +68,7 @@
     mrbc_array_minmax
     mrbc_array_dup
     mrbc_array_divide
+    mrbc_array_include
 */
 
 
@@ -530,6 +531,23 @@ mrbc_value mrbc_array_divide(struct VM *vm, mrbc_value *src, int pos)
   return ret;
 }
 
+//================================================================
+/*! check inclusion
+
+  @param  ary     source
+  @param  val     object if it is included
+  @return         0 if not included. 1 or greater if included
+*/
+int mrbc_array_include(const mrbc_value *ary, const mrbc_value *val)
+{
+  int n = ary->array->n_stored;
+  int i;
+  for (i = 0; i < n; i++) {
+    if (mrbc_compare(&ary->array->data[i], val) == 0) break;
+  }
+  return (n - i);
+}
+
 
 //================================================================
 /*! method new
@@ -811,16 +829,7 @@ static void c_array_size(struct VM *vm, mrbc_value v[], int argc)
 */
 static void c_array_include(struct VM *vm, mrbc_value v[], int argc)
 {
-  const mrbc_value *value = &v[1];
-  const mrbc_value *data = v[0].array->data;
-  int n = v[0].array->n_stored;
-  int i;
-
-  for( i = 0; i < n; i++ ) {
-    if( mrbc_compare(&data[i], value) == 0 ) break;
-  }
-
-  SET_BOOL_RETURN( i < n );
+  SET_BOOL_RETURN(0 < mrbc_array_include(&v[0], &v[1]));
 }
 
 

--- a/src/c_array.c
+++ b/src/c_array.c
@@ -834,6 +834,57 @@ static void c_array_include(struct VM *vm, mrbc_value v[], int argc)
 
 
 //================================================================
+/*! (method) &
+*/
+static void c_array_and(struct VM *vm, mrbc_value v[], int argc)
+{
+  if (v[1].tt != MRBC_TT_ARRAY) {
+    mrbc_raise( vm, MRBC_CLASS(TypeError), "no implicit conversion into Array");
+    return;
+  }
+  mrbc_value result = mrbc_array_new(vm, 0);
+  int i;
+  for (i = 0; i < v[0].array->n_stored; i++) {
+    mrbc_value *data = &v[0].array->data[i];
+    if (0 < mrbc_array_include(&v[1], data) && 0 == mrbc_array_include(&result, data))
+    {
+      mrbc_array_push(&result, data);
+    }
+  }
+  SET_RETURN(result);
+}
+
+
+//================================================================
+/*! (method) |
+*/
+static void c_array_or(struct VM *vm, mrbc_value v[], int argc)
+{
+  if (v[1].tt != MRBC_TT_ARRAY) {
+    mrbc_raise( vm, MRBC_CLASS(TypeError), "no implicit conversion into Array");
+    return;
+  }
+  mrbc_value result = mrbc_array_new(vm, 0);
+  int i;
+  for (i = 0; i < v[0].array->n_stored; i++) {
+    mrbc_value *data = &v[0].array->data[i];
+    if (0 == mrbc_array_include(&result, data))
+    {
+      mrbc_array_push(&result, data);
+    }
+  }
+  for (i = 0; i < v[1].array->n_stored; i++) {
+    mrbc_value *data = &v[1].array->data[i];
+    if (0 == mrbc_array_include(&result, data))
+    {
+      mrbc_array_push(&result, data);
+    }
+  }
+  SET_RETURN(result);
+}
+
+
+//================================================================
 /*! (method) first
 */
 static void c_array_first(struct VM *vm, mrbc_value v[], int argc)
@@ -1110,6 +1161,8 @@ static void c_array_join(struct VM *vm, mrbc_value v[], int argc)
   METHOD( "length",	c_array_size )
   METHOD( "count",	c_array_size )
   METHOD( "include?",	c_array_include )
+  METHOD( "&",		c_array_and )
+  METHOD( "|",		c_array_or )
   METHOD( "first",	c_array_first )
   METHOD( "last",	c_array_last )
   METHOD( "push",	c_array_push )

--- a/src/c_array.h
+++ b/src/c_array.h
@@ -67,7 +67,7 @@ int mrbc_array_compare(const mrbc_value *v1, const mrbc_value *v2);
 void mrbc_array_minmax(mrbc_value *ary, mrbc_value **pp_min_value, mrbc_value **pp_max_value);
 mrbc_value mrbc_array_dup(struct VM *vm, const mrbc_value *ary);
 mrbc_value mrbc_array_divide(struct VM *vm, mrbc_value *src, int pos);
-
+int mrbc_array_include(const mrbc_value *ary, const mrbc_value *val);
 
 /***** Inline functions *****************************************************/
 //================================================================

--- a/test/array_test.rb
+++ b/test/array_test.rb
@@ -286,4 +286,13 @@ class ArrayTest < MrubycTestCase
     assert_equal [2,4,6], a
   end
 
+  description "include?"
+  def include_case
+    assert_true [1,2,3].include?(1)
+    assert_true [[1],2,3].include?([1])
+    assert_false [1,2,3].include?(4)
+    assert_false [1,2,3].include?("3")
+    assert_false [].include?(true)
+  end
+
 end

--- a/test/array_test.rb
+++ b/test/array_test.rb
@@ -295,4 +295,20 @@ class ArrayTest < MrubycTestCase
     assert_false [].include?(true)
   end
 
+  description "& (and) operation"
+  def and_operation
+    assert_equal [1, 3], [1, 1, 2, 3] & [3, 1, 4]
+    assert_raise(TypeError.new("no implicit conversion into Array")) do
+      [1] & 1
+    end
+  end
+
+  description "| (or) operation"
+  def or_operation
+    assert_equal [1, 4, 2, 3, 5], [1, 1, 4, 2, 3] | [5, 4, 5]
+    assert_raise(TypeError.new("no implicit conversion into Array")) do
+      [1] | "1"
+    end
+  end
+
 end


### PR DESCRIPTION
- Separate `mrbc_array_include()` from `c_array_include()` so that it can be used by Array#& and Array#|
- Add tests for Array#include? as they didn't exist