### PR TITLE
Remove nil from description for String#<=>

### DIFF
--- a/test/string_test.rb
+++ b/test/string_test.rb
@@ -55,7 +55,7 @@ class StringTest < MrubycTestCase
     assert_equal "ABCDEFG0123456789abcA", s1
   end
 
-  description "self <=> other -> (minus) | 0 | (plus) | nil"
+  description "self <=> other -> (minus) | 0 | (plus)"
   def compare_case
     assert ("aaa" <=> "xxx") < 0
     assert ("aaa" <=> "aaa") == 0


### PR DESCRIPTION
`mrbc_string_compare` always returns integer, so nil is never returned.

https://github.com/mrubyc/mrubyc/blob/b1192d538caba230a1ad0d1cf8aeecf5aae0d778/src/c_string.h#L76-L87

