### PR TITLE
Enable passing docker build options to `make setup_test`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ check_tag:
 	fi
 
 setup_test:
-	docker build -t mrubyc-dev --build-arg MRUBY_TAG=$(MRUBY_TAG) --build-arg USER_ID=$(USER_ID) .
+	docker build -t mrubyc-dev --build-arg MRUBY_TAG=$(MRUBY_TAG) --build-arg USER_ID=$(USER_ID) $(options) .
 
 debug_test:
 	gdb $(OPTION) --directory $(shell pwd)/src --args test/tmp/test

--- a/doc/test.md
+++ b/doc/test.md
@@ -18,6 +18,12 @@ make setup_test
 This target will build a Docker container image.
 It may take a while.
 
+### Passing docker build options
+
+```
+make setup_test options="--no-cache --quiet"
+```
+
 ## Test!
 
 ```


### PR DESCRIPTION
Because I would like to build with --no-cache in bundle install, etc.