### PR TITLE
initialize siz

### DIFF
--- a/src/load.c
+++ b/src/load.c
@@ -213,7 +213,7 @@ static mrbc_irep * load_irep_1(struct VM *vm, const uint8_t *bin, int *len, int 
   uint16_t *ofs_pools = mrbc_irep_tbl_pools(p_irep);
   p = p_irep->pool + 2;
   for( i = 0; i < irep.plen; i++ ) {
-    int siz;
+    int siz = 0;
     if( (p - irep.pool) > UINT16_MAX ) {
       mrbc_raise(vm, MRBC_CLASS(Exception), "Overflow IREP data offset table.");
       return NULL;


### PR DESCRIPTION
I compiled it with PlatformIO on VSCode.
It shows the error "lib/mrubyc/src/load.c:225:7: error: 'siz' may be used uninitialized in this function [-Werror=maybe-uninitialized]", then failed to compile.

I think zero is appropriate; if it's not, please set the correct value.