### PR TITLE
Add check for empty string

### DIFF
--- a/src/c_string.c
+++ b/src/c_string.c
@@ -754,6 +754,11 @@ static void c_string_ord(struct VM *vm, mrbc_value v[], int argc)
 {
   int i = ((uint8_t *)mrbc_string_cstr(v))[0];
 
+  if (i == 0) {
+    mrbc_raise(vm, MRBC_CLASS(ArgumentError), "empty string");
+    return;
+  }
+
   SET_INT_RETURN( i );
 }
 

--- a/test/string_test.rb
+++ b/test/string_test.rb
@@ -383,6 +383,10 @@ class StringTest < MrubycTestCase
   def ord_case
     assert_equal 97, "a".ord
     assert_equal 97, "abcde".ord
+
+    assert_raise(ArgumentError.new("empty string")) do
+      "".ord
+    end
   end
 
   description "binary string"


### PR DESCRIPTION
I added a check for empty strings in String#ord. This is the same behavior as in Ruby.

NOTE
Before I added the check, `"".ord` raised ArgumentError during the `make test`. Could this be raised by the mruby compiler?