### PR TITLE
Fix allocated vm size considerd memory paddings

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -311,7 +311,7 @@ void mrbc_pop_callinfo( struct VM *vm )
 */
 mrbc_vm * mrbc_vm_new( int regs_size )
 {
-  mrbc_vm *vm = mrbc_raw_alloc(sizeof(mrbc_vm) + sizeof(mrbc_value) * regs_size);
+  mrbc_vm *vm = mrbc_raw_alloc(offsetof(mrbc_vm, regs) + sizeof(mrbc_value) * regs_size);
   if( !vm ) return NULL;
 
   memset(vm, 0, sizeof(mrbc_vm));	// caution: assume NULL is zero.


### PR DESCRIPTION
trailing padding should be considered when getting mrbc_vm's size

ref: (in japanese) https://www.buildinsider.net/language/clang/01 I haven't checked original C99 spec, but it sounds making sense