### PR TITLE
remove the end year in copyright notice

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 BSD 3-Clause License
 
-Copyright (c) 2015-2022 Kyushu Institute of Technology All right reserved.
-Copyright (c) 2015-2022 Shimane IT Open-Innovation Center All right reserved.
+Copyright (c) 2015- Kyushu Institute of Technology All right reserved.
+Copyright (c) 2015- Shimane IT Open-Innovation Center All right reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 #
 # mruby/c  Makefile
 #
-# Copyright (C) 2015-2021 Kyushu Institute of Technology.
-# Copyright (C) 2015-2021 Shimane IT Open-Innovation Center.
+# Copyright (C) 2015- Kyushu Institute of Technology.
+# Copyright (C) 2015- Shimane IT Open-Innovation Center.
 #
 #  This file is distributed under BSD 3-Clause License.
 #

--- a/mrblib/Makefile
+++ b/mrblib/Makefile
@@ -1,8 +1,8 @@
 #
 # mruby/c  Makefile
 #
-# Copyright (C) 2015-2023 Kyushu Institute of Technology.
-# Copyright (C) 2015-2023 Shimane IT Open-Innovation Center.
+# Copyright (C) 2015- Kyushu Institute of Technology.
+# Copyright (C) 2015- Shimane IT Open-Innovation Center.
 #
 #  This file is distributed under BSD 3-Clause License.
 #

--- a/mrblib/array.rb
+++ b/mrblib/array.rb
@@ -1,8 +1,8 @@
 #
 # Array, mrubyc class library
 #
-#  Copyright (C) 2015-2022 Kyushu Institute of Technology.
-#  Copyright (C) 2015-2022 Shimane IT Open-Innovation Center.
+#  Copyright (C) 2015- Kyushu Institute of Technology.
+#  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 #
 #  This file is distributed under BSD 3-Clause License.
 #

--- a/mrblib/global.rb
+++ b/mrblib/global.rb
@@ -1,8 +1,8 @@
 #
 # Object, mrubyc class library
 #
-#  Copyright (C) 2015-2020 Kyushu Institute of Technology.
-#  Copyright (C) 2015-2020 Shimane IT Open-Innovation Center.
+#  Copyright (C) 2015- Kyushu Institute of Technology.
+#  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 #
 #  This file is distributed under BSD 3-Clause License.
 #

--- a/mrblib/hash.rb
+++ b/mrblib/hash.rb
@@ -1,8 +1,8 @@
 #
 # Hash, mrubyc class library
 #
-#  Copyright (C) 2015-2019 Kyushu Institute of Technology.
-#  Copyright (C) 2015-2019 Shimane IT Open-Innovation Center.
+#  Copyright (C) 2015- Kyushu Institute of Technology.
+#  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 #
 #  This file is distributed under BSD 3-Clause License.
 #

--- a/mrblib/numeric.rb
+++ b/mrblib/numeric.rb
@@ -1,8 +1,8 @@
 #
 # Integer, mrubyc class library
 #
-#  Copyright (C) 2015-2021 Kyushu Institute of Technology.
-#  Copyright (C) 2015-2021 Shimane IT Open-Innovation Center.
+#  Copyright (C) 2015- Kyushu Institute of Technology.
+#  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 #
 #  This file is distributed under BSD 3-Clause License.
 #

--- a/mrblib/object.rb
+++ b/mrblib/object.rb
@@ -1,8 +1,8 @@
 #
 # Object, mrubyc class library
 #
-#  Copyright (C) 2015-2020 Kyushu Institute of Technology.
-#  Copyright (C) 2015-2020 Shimane IT Open-Innovation Center.
+#  Copyright (C) 2015- Kyushu Institute of Technology.
+#  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 #
 #  This file is distributed under BSD 3-Clause License.
 #

--- a/mrblib/range.rb
+++ b/mrblib/range.rb
@@ -1,8 +1,8 @@
 #
 # Range, mrubyc class library
 #
-#  Copyright (C) 2015-2018 Kyushu Institute of Technology.
-#  Copyright (C) 2015-2018 Shimane IT Open-Innovation Center.
+#  Copyright (C) 2015- Kyushu Institute of Technology.
+#  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 #
 #  This file is distributed under BSD 3-Clause License.
 #

--- a/mrblib/string.rb
+++ b/mrblib/string.rb
@@ -1,8 +1,8 @@
 #
 # String, mrubyc class library
 #
-#  Copyright (C) 2015-2018 Kyushu Institute of Technology.
-#  Copyright (C) 2015-2018 Shimane IT Open-Innovation Center.
+#  Copyright (C) 2015- Kyushu Institute of Technology.
+#  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 #
 #  This file is distributed under BSD 3-Clause License.
 #

--- a/sample_c/Makefile
+++ b/sample_c/Makefile
@@ -1,8 +1,8 @@
 #
 # mruby/c  sample_c/Makefile
 #
-# Copyright (C) 2015-2021 Kyushu Institute of Technology.
-# Copyright (C) 2015-2021 Shimane IT Open-Innovation Center.
+# Copyright (C) 2015- Kyushu Institute of Technology.
+# Copyright (C) 2015- Shimane IT Open-Innovation Center.
 #
 #  This file is distributed under BSD 3-Clause License.
 #

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,8 +1,8 @@
 #
 # mruby/c  src/Makefile
 #
-# Copyright (C) 2015-2023 Kyushu Institute of Technology.
-# Copyright (C) 2015-2023 Shimane IT Open-Innovation Center.
+# Copyright (C) 2015- Kyushu Institute of Technology.
+# Copyright (C) 2015- Shimane IT Open-Innovation Center.
 #
 #  This file is distributed under BSD 3-Clause License.
 #

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -3,8 +3,8 @@
   mruby/c memory management.
 
   <pre>
-  Copyright (C) 2015-2022 Kyushu Institute of Technology.
-  Copyright (C) 2015-2022 Shimane IT Open-Innovation Center.
+  Copyright (C) 2015- Kyushu Institute of Technology.
+  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
 

--- a/src/alloc.h
+++ b/src/alloc.h
@@ -3,8 +3,8 @@
   mruby/c memory management.
 
   <pre>
-  Copyright (C) 2015-2022 Kyushu Institute of Technology.
-  Copyright (C) 2015-2022 Shimane IT Open-Innovation Center.
+  Copyright (C) 2015- Kyushu Institute of Technology.
+  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
 

--- a/src/c_array.c
+++ b/src/c_array.c
@@ -3,8 +3,8 @@
   mruby/c Array class
 
   <pre>
-  Copyright (C) 2015-2022 Kyushu Institute of Technology.
-  Copyright (C) 2015-2022 Shimane IT Open-Innovation Center.
+  Copyright (C) 2015- Kyushu Institute of Technology.
+  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
 

--- a/src/c_array.h
+++ b/src/c_array.h
@@ -3,8 +3,8 @@
   mruby/c Array class
 
   <pre>
-  Copyright (C) 2015-2022 Kyushu Institute of Technology.
-  Copyright (C) 2015-2022 Shimane IT Open-Innovation Center.
+  Copyright (C) 2015- Kyushu Institute of Technology.
+  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
 

--- a/src/c_hash.c
+++ b/src/c_hash.c
@@ -3,8 +3,8 @@
   mruby/c Hash class
 
   <pre>
-  Copyright (C) 2015-2023 Kyushu Institute of Technology.
-  Copyright (C) 2015-2023 Shimane IT Open-Innovation Center.
+  Copyright (C) 2015- Kyushu Institute of Technology.
+  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
 

--- a/src/c_hash.h
+++ b/src/c_hash.h
@@ -3,8 +3,8 @@
   mruby/c Hash class
 
   <pre>
-  Copyright (C) 2015-2023 Kyushu Institute of Technology.
-  Copyright (C) 2015-2023 Shimane IT Open-Innovation Center.
+  Copyright (C) 2015- Kyushu Institute of Technology.
+  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
 

--- a/src/c_math.c
+++ b/src/c_math.c
@@ -3,8 +3,8 @@
   mruby/c Math class
 
   <pre>
-  Copyright (C) 2015-2021 Kyushu Institute of Technology.
-  Copyright (C) 2015-2021 Shimane IT Open-Innovation Center.
+  Copyright (C) 2015- Kyushu Institute of Technology.
+  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
 

--- a/src/c_math.h
+++ b/src/c_math.h
@@ -3,8 +3,8 @@
   mruby/c Math class
 
   <pre>
-  Copyright (C) 2015-2018 Kyushu Institute of Technology.
-  Copyright (C) 2015-2018 Shimane IT Open-Innovation Center.
+  Copyright (C) 2015- Kyushu Institute of Technology.
+  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
 

--- a/src/c_numeric.c
+++ b/src/c_numeric.c
@@ -3,8 +3,8 @@
   mruby/c Integer and Float class
 
   <pre>
-  Copyright (C) 2015-2023 Kyushu Institute of Technology.
-  Copyright (C) 2015-2023 Shimane IT Open-Innovation Center.
+  Copyright (C) 2015- Kyushu Institute of Technology.
+  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
 

--- a/src/c_numeric.h
+++ b/src/c_numeric.h
@@ -3,8 +3,8 @@
   mruby/c Integer and Float class
 
   <pre>
-  Copyright (C) 2015 Kyushu Institute of Technology.
-  Copyright (C) 2015 Shimane IT Open-Innovation Center.
+  Copyright (C) 2015- Kyushu Institute of Technology.
+  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
 

--- a/src/c_object.c
+++ b/src/c_object.c
@@ -3,8 +3,8 @@
   Object, Proc, Nil, True and False class.
 
   <pre>
-  Copyright (C) 2015-2023 Kyushu Institute of Technology.
-  Copyright (C) 2015-2023 Shimane IT Open-Innovation Center.
+  Copyright (C) 2015- Kyushu Institute of Technology.
+  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
 

--- a/src/c_object.h
+++ b/src/c_object.h
@@ -3,8 +3,8 @@
   Object, Proc, Nil, True and False class.
 
   <pre>
-  Copyright (C) 2015-2023 Kyushu Institute of Technology.
-  Copyright (C) 2015-2023 Shimane IT Open-Innovation Center.
+  Copyright (C) 2015- Kyushu Institute of Technology.
+  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
 

--- a/src/c_range.c
+++ b/src/c_range.c
@@ -3,8 +3,8 @@
   mruby/c Range class
 
   <pre>
-  Copyright (C) 2015-2022 Kyushu Institute of Technology.
-  Copyright (C) 2015-2022 Shimane IT Open-Innovation Center.
+  Copyright (C) 2015- Kyushu Institute of Technology.
+  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
 

--- a/src/c_range.h
+++ b/src/c_range.h
@@ -3,8 +3,8 @@
   mruby/c Range class
 
   <pre>
-  Copyright (C) 2015-2022 Kyushu Institute of Technology.
-  Copyright (C) 2015-2022 Shimane IT Open-Innovation Center.
+  Copyright (C) 2015- Kyushu Institute of Technology.
+  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
 

--- a/src/c_string.c
+++ b/src/c_string.c
@@ -3,8 +3,8 @@
   mruby/c String class
 
   <pre>
-  Copyright (C) 2015-2023 Kyushu Institute of Technology.
-  Copyright (C) 2015-2023 Shimane IT Open-Innovation Center.
+  Copyright (C) 2015- Kyushu Institute of Technology.
+  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
 

--- a/src/c_string.h
+++ b/src/c_string.h
@@ -3,8 +3,8 @@
   mruby/c String class
 
   <pre>
-  Copyright (C) 2015-2023 Kyushu Institute of Technology.
-  Copyright (C) 2015-2023 Shimane IT Open-Innovation Center.
+  Copyright (C) 2015- Kyushu Institute of Technology.
+  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
 

--- a/src/class.c
+++ b/src/class.c
@@ -3,8 +3,8 @@
   Class related functions.
 
   <pre>
-  Copyright (C) 2015-2022 Kyushu Institute of Technology.
-  Copyright (C) 2015-2022 Shimane IT Open-Innovation Center.
+  Copyright (C) 2015- Kyushu Institute of Technology.
+  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
 

--- a/src/class.h
+++ b/src/class.h
@@ -3,8 +3,8 @@
   Class related functions.
 
   <pre>
-  Copyright (C) 2015-2022 Kyushu Institute of Technology.
-  Copyright (C) 2015-2022 Shimane IT Open-Innovation Center.
+  Copyright (C) 2015- Kyushu Institute of Technology.
+  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
 

--- a/src/console.c
+++ b/src/console.c
@@ -3,8 +3,8 @@
   console output module. (not yet input)
 
   <pre>
-  Copyright (C) 2015-2023 Kyushu Institute of Technology.
-  Copyright (C) 2015-2023 Shimane IT Open-Innovation Center.
+  Copyright (C) 2015- Kyushu Institute of Technology.
+  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
 

--- a/src/console.h
+++ b/src/console.h
@@ -3,8 +3,8 @@
   console output module. (not yet input)
 
   <pre>
-  Copyright (C) 2015-2023 Kyushu Institute of Technology.
-  Copyright (C) 2015-2023 Shimane IT Open-Innovation Center.
+  Copyright (C) 2015- Kyushu Institute of Technology.
+  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
 

--- a/src/error.c
+++ b/src/error.c
@@ -3,8 +3,8 @@
   exception classes
 
   <pre>
-  Copyright (C) 2015-2023 Kyushu Institute of Technology.
-  Copyright (C) 2015-2023 Shimane IT Open-Innovation Center.
+  Copyright (C) 2015- Kyushu Institute of Technology.
+  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
 

--- a/src/error.h
+++ b/src/error.h
@@ -3,8 +3,8 @@
   exception classes
 
   <pre>
-  Copyright (C) 2015-2022 Kyushu Institute of Technology.
-  Copyright (C) 2015-2022 Shimane IT Open-Innovation Center.
+  Copyright (C) 2015- Kyushu Institute of Technology.
+  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
 

--- a/src/global.c
+++ b/src/global.c
@@ -3,8 +3,8 @@
   Constant and global variables.
 
   <pre>
-  Copyright (C) 2015-2023 Kyushu Institute of Technology.
-  Copyright (C) 2015-2023 Shimane IT Open-Innovation Center.
+  Copyright (C) 2015- Kyushu Institute of Technology.
+  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
 

--- a/src/global.h
+++ b/src/global.h
@@ -3,8 +3,8 @@
   Constant and global variables.
 
   <pre>
-  Copyright (C) 2015-2023 Kyushu Institute of Technology.
-  Copyright (C) 2015-2023 Shimane IT Open-innovation Center.
+  Copyright (C) 2015- Kyushu Institute of Technology.
+  Copyright (C) 2015- Shimane IT Open-innovation Center.
 
   This file is distributed under BSD 3-Clause License.
 

--- a/src/hal_esp32/hal.c
+++ b/src/hal_esp32/hal.c
@@ -4,8 +4,8 @@
         for ESP32
 
   <pre>
-  Copyright (C) 2016- Kyushu Institute of Technology.
-  Copyright (C) 2016- Shimane IT Open-Innovation Center.
+  Copyright (C) 2015- Kyushu Institute of Technology.
+  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
   </pre>

--- a/src/hal_esp32/hal.c
+++ b/src/hal_esp32/hal.c
@@ -4,8 +4,8 @@
         for ESP32
 
   <pre>
-  Copyright (C) 2016-2018 Kyushu Institute of Technology.
-  Copyright (C) 2016-2018 Shimane IT Open-Innovation Center.
+  Copyright (C) 2016- Kyushu Institute of Technology.
+  Copyright (C) 2016- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
   </pre>

--- a/src/hal_esp32/hal.h
+++ b/src/hal_esp32/hal.h
@@ -4,8 +4,8 @@
         for ESP32
 
   <pre>
-  Copyright (C) 2016- Kyushu Institute of Technology.
-  Copyright (C) 2016- Shimane IT Open-Innovation Center.
+  Copyright (C) 2015- Kyushu Institute of Technology.
+  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
   </pre>

--- a/src/hal_esp32/hal.h
+++ b/src/hal_esp32/hal.h
@@ -4,8 +4,8 @@
         for ESP32
 
   <pre>
-  Copyright (C) 2016-2018 Kyushu Institute of Technology.
-  Copyright (C) 2016-2018 Shimane IT Open-Innovation Center.
+  Copyright (C) 2016- Kyushu Institute of Technology.
+  Copyright (C) 2016- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
   </pre>

--- a/src/hal_pic24/hal.h
+++ b/src/hal_pic24/hal.h
@@ -4,8 +4,8 @@
         for Microchip PIC24
 
   <pre>
-  Copyright (C) 2016-2021 Kyushu Institute of Technology.
-  Copyright (C) 2016-2021 Shimane IT Open-Innovation Center.
+  Copyright (C) 2016- Kyushu Institute of Technology.
+  Copyright (C) 2016- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
   </pre>

--- a/src/hal_pic24/hal.h
+++ b/src/hal_pic24/hal.h
@@ -4,8 +4,8 @@
         for Microchip PIC24
 
   <pre>
-  Copyright (C) 2016- Kyushu Institute of Technology.
-  Copyright (C) 2016- Shimane IT Open-Innovation Center.
+  Copyright (C) 2015- Kyushu Institute of Technology.
+  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
   </pre>

--- a/src/hal_posix/hal.c
+++ b/src/hal_posix/hal.c
@@ -4,8 +4,8 @@
         for POSIX
 
   <pre>
-  Copyright (C) 2016-2021 Kyushu Institute of Technology.
-  Copyright (C) 2016-2021 Shimane IT Open-Innovation Center.
+  Copyright (C) 2016- Kyushu Institute of Technology.
+  Copyright (C) 2016- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
   </pre>

--- a/src/hal_posix/hal.c
+++ b/src/hal_posix/hal.c
@@ -4,8 +4,8 @@
         for POSIX
 
   <pre>
-  Copyright (C) 2016- Kyushu Institute of Technology.
-  Copyright (C) 2016- Shimane IT Open-Innovation Center.
+  Copyright (C) 2015- Kyushu Institute of Technology.
+  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
   </pre>

--- a/src/hal_posix/hal.h
+++ b/src/hal_posix/hal.h
@@ -4,8 +4,8 @@
         for POSIX
 
   <pre>
-  Copyright (C) 2016-2021 Kyushu Institute of Technology.
-  Copyright (C) 2016-2021 Shimane IT Open-Innovation Center.
+  Copyright (C) 2016- Kyushu Institute of Technology.
+  Copyright (C) 2016- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
   </pre>

--- a/src/hal_posix/hal.h
+++ b/src/hal_posix/hal.h
@@ -4,8 +4,8 @@
         for POSIX
 
   <pre>
-  Copyright (C) 2016- Kyushu Institute of Technology.
-  Copyright (C) 2016- Shimane IT Open-Innovation Center.
+  Copyright (C) 2015- Kyushu Institute of Technology.
+  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
   </pre>

--- a/src/hal_psoc5lp/hal.c
+++ b/src/hal_psoc5lp/hal.c
@@ -4,8 +4,8 @@
         for PSoC5LP
 
   <pre>
-  Copyright (C) 2016-2021 Kyushu Institute of Technology.
-  Copyright (C) 2016-2021 Shimane IT Open-Innovation Center.
+  Copyright (C) 2016- Kyushu Institute of Technology.
+  Copyright (C) 2016- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
   </pre>

--- a/src/hal_psoc5lp/hal.c
+++ b/src/hal_psoc5lp/hal.c
@@ -4,8 +4,8 @@
         for PSoC5LP
 
   <pre>
-  Copyright (C) 2016- Kyushu Institute of Technology.
-  Copyright (C) 2016- Shimane IT Open-Innovation Center.
+  Copyright (C) 2015- Kyushu Institute of Technology.
+  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
   </pre>

--- a/src/hal_psoc5lp/hal.h
+++ b/src/hal_psoc5lp/hal.h
@@ -4,8 +4,8 @@
         for PSoC5LP
 
   <pre>
-  Copyright (C) 2016-2021 Kyushu Institute of Technology.
-  Copyright (C) 2016-2021 Shimane IT Open-Innovation Center.
+  Copyright (C) 2016- Kyushu Institute of Technology.
+  Copyright (C) 2016- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
   </pre>

--- a/src/hal_psoc5lp/hal.h
+++ b/src/hal_psoc5lp/hal.h
@@ -4,8 +4,8 @@
         for PSoC5LP
 
   <pre>
-  Copyright (C) 2016- Kyushu Institute of Technology.
-  Copyright (C) 2016- Shimane IT Open-Innovation Center.
+  Copyright (C) 2015- Kyushu Institute of Technology.
+  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
   </pre>

--- a/src/hal_rp2040/hal.c
+++ b/src/hal_rp2040/hal.c
@@ -4,8 +4,8 @@
         for RP2040
 
   <pre>
-  Copyright (C) 2016-2021 Kyushu Institute of Technology.
-  Copyright (C) 2016-2021 Shimane IT Open-Innovation Center.
+  Copyright (C) 2016- Kyushu Institute of Technology.
+  Copyright (C) 2016- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
   </pre>

--- a/src/hal_rp2040/hal.c
+++ b/src/hal_rp2040/hal.c
@@ -4,8 +4,8 @@
         for RP2040
 
   <pre>
-  Copyright (C) 2016- Kyushu Institute of Technology.
-  Copyright (C) 2016- Shimane IT Open-Innovation Center.
+  Copyright (C) 2015- Kyushu Institute of Technology.
+  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
   </pre>

--- a/src/hal_rp2040/hal.h
+++ b/src/hal_rp2040/hal.h
@@ -4,8 +4,8 @@
         for RP2040
 
   <pre>
-  Copyright (C) 2016-2021 Kyushu Institute of Technology.
-  Copyright (C) 2016-2021 Shimane IT Open-Innovation Center.
+  Copyright (C) 2016- Kyushu Institute of Technology.
+  Copyright (C) 2016- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
   </pre>

--- a/src/hal_rp2040/hal.h
+++ b/src/hal_rp2040/hal.h
@@ -4,8 +4,8 @@
         for RP2040
 
   <pre>
-  Copyright (C) 2016- Kyushu Institute of Technology.
-  Copyright (C) 2016- Shimane IT Open-Innovation Center.
+  Copyright (C) 2015- Kyushu Institute of Technology.
+  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
   </pre>

--- a/src/hal_selector.h
+++ b/src/hal_selector.h
@@ -8,8 +8,8 @@
   See also mrubyc/src/Makefile
 
   <pre>
-  Copyright (C) 2016-2021 Kyushu Institute of Technology.
-  Copyright (C) 2016-2021 Shimane IT Open-Innovation Center.
+  Copyright (C) 2016- Kyushu Institute of Technology.
+  Copyright (C) 2016- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
   </pre>

--- a/src/hal_selector.h
+++ b/src/hal_selector.h
@@ -8,8 +8,8 @@
   See also mrubyc/src/Makefile
 
   <pre>
-  Copyright (C) 2016- Kyushu Institute of Technology.
-  Copyright (C) 2016- Shimane IT Open-Innovation Center.
+  Copyright (C) 2015- Kyushu Institute of Technology.
+  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
   </pre>

--- a/src/hal_selector.mk
+++ b/src/hal_selector.mk
@@ -1,8 +1,8 @@
 #
 # mruby/c  src/hal_selector.mk
 #
-# Copyright (C) 2015-2021 Kyushu Institute of Technology.
-# Copyright (C) 2015-2021 Shimane IT Open-Innovation Center.
+# Copyright (C) 2015- Kyushu Institute of Technology.
+# Copyright (C) 2015- Shimane IT Open-Innovation Center.
 #
 #  This file is distributed under BSD 3-Clause License.
 #

--- a/src/keyvalue.c
+++ b/src/keyvalue.c
@@ -3,8 +3,8 @@
   mruby/c Key(Symbol) - Value store.
 
   <pre>
-  Copyright (C) 2015-2022 Kyushu Institute of Technology.
-  Copyright (C) 2015-2022 Shimane IT Open-Innovation Center.
+  Copyright (C) 2015- Kyushu Institute of Technology.
+  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
 

--- a/src/keyvalue.h
+++ b/src/keyvalue.h
@@ -3,8 +3,8 @@
   mruby/c Key(Symbol) - Value store.
 
   <pre>
-  Copyright (C) 2015-2022 Kyushu Institute of Technology.
-  Copyright (C) 2015-2022 Shimane IT Open-Innovation Center.
+  Copyright (C) 2015- Kyushu Institute of Technology.
+  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
 

--- a/src/load.c
+++ b/src/load.c
@@ -3,8 +3,8 @@
   mruby bytecode loader.
 
   <pre>
-  Copyright (C) 2015-2023 Kyushu Institute of Technology.
-  Copyright (C) 2015-2023 Shimane IT Open-Innovation Center.
+  Copyright (C) 2015- Kyushu Institute of Technology.
+  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
 

--- a/src/load.h
+++ b/src/load.h
@@ -3,8 +3,8 @@
   mruby bytecode loader.
 
   <pre>
-  Copyright (C) 2015-2021 Kyushu Institute of Technology.
-  Copyright (C) 2015-2021 Shimane IT Open-Innovation Center.
+  Copyright (C) 2015- Kyushu Institute of Technology.
+  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
 

--- a/src/mrubyc.h
+++ b/src/mrubyc.h
@@ -3,8 +3,8 @@
   Include at once the necessary header files for user program.
 
   <pre>
-  Copyright (C) 2015-2020 Kyushu Institute of Technology.
-  Copyright (C) 2015-2020 Shimane IT Open-Innovation Center.
+  Copyright (C) 2015- Kyushu Institute of Technology.
+  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
 

--- a/src/opcode.h
+++ b/src/opcode.h
@@ -3,8 +3,8 @@
   Define operation codes and associated macros.
 
   <pre>
-  Copyright (C) 2015-2022 Kyushu Institute of Technology.
-  Copyright (C) 2015-2022 Shimane IT Open-Innovation Center.
+  Copyright (C) 2015- Kyushu Institute of Technology.
+  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
 

--- a/src/rrt0.c
+++ b/src/rrt0.c
@@ -3,8 +3,8 @@
   Realtime multitask monitor for mruby/c
 
   <pre>
-  Copyright (C) 2015-2022 Kyushu Institute of Technology.
-  Copyright (C) 2015-2022 Shimane IT Open-Innovation Center.
+  Copyright (C) 2015- Kyushu Institute of Technology.
+  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
   </pre>

--- a/src/rrt0.h
+++ b/src/rrt0.h
@@ -3,8 +3,8 @@
   Realtime multitask monitor for mruby/c
 
   <pre>
-  Copyright (C) 2015-2018 Kyushu Institute of Technology.
-  Copyright (C) 2015-2018 Shimane IT Open-Innovation Center.
+  Copyright (C) 2015- Kyushu Institute of Technology.
+  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
   </pre>

--- a/src/symbol.c
+++ b/src/symbol.c
@@ -3,8 +3,8 @@
   mruby/c Symbol class
 
   <pre>
-  Copyright (C) 2015-2023 Kyushu Institute of Technology.
-  Copyright (C) 2015-2023 Shimane IT Open-Innovation Center.
+  Copyright (C) 2015- Kyushu Institute of Technology.
+  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
 

--- a/src/symbol.h
+++ b/src/symbol.h
@@ -3,8 +3,8 @@
   mruby/c Symbol class
 
   <pre>
-  Copyright (C) 2015-2023 Kyushu Institute of Technology.
-  Copyright (C) 2015-2023 Shimane IT Open-Innovation Center.
+  Copyright (C) 2015- Kyushu Institute of Technology.
+  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
 

--- a/src/value.c
+++ b/src/value.c
@@ -3,8 +3,8 @@
   mruby/c value definitions
 
   <pre>
-  Copyright (C) 2015-2023 Kyushu Institute of Technology.
-  Copyright (C) 2015-2023 Shimane IT Open-Innovation Center.
+  Copyright (C) 2015- Kyushu Institute of Technology.
+  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
 

--- a/src/value.h
+++ b/src/value.h
@@ -3,8 +3,8 @@
   mruby/c value definitions
 
   <pre>
-  Copyright (C) 2015-2023 Kyushu Institute of Technology.
-  Copyright (C) 2015-2023 Shimane IT Open-Innovation Center.
+  Copyright (C) 2015- Kyushu Institute of Technology.
+  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
 

--- a/src/vm.c
+++ b/src/vm.c
@@ -3,8 +3,8 @@
   mruby bytecode executor.
 
   <pre>
-  Copyright (C) 2015-2023 Kyushu Institute of Technology.
-  Copyright (C) 2015-2023 Shimane IT Open-Innovation Center.
+  Copyright (C) 2015- Kyushu Institute of Technology.
+  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
 

--- a/src/vm.h
+++ b/src/vm.h
@@ -3,8 +3,8 @@
   mruby bytecode executor.
 
   <pre>
-  Copyright (C) 2015-2022 Kyushu Institute of Technology.
-  Copyright (C) 2015-2022 Shimane IT Open-Innovation Center.
+  Copyright (C) 2015- Kyushu Institute of Technology.
+  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
 

--- a/src/vm_config.h
+++ b/src/vm_config.h
@@ -3,8 +3,8 @@
   Global configuration of mruby/c VM's
 
   <pre>
-  Copyright (C) 2015-2023 Kyushu Institute of Technology.
-  Copyright (C) 2015-2023 Shimane IT Open-Innovation Center.
+  Copyright (C) 2015- Kyushu Institute of Technology.
+  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 
   This file is distributed under BSD 3-Clause License.
   </pre>

--- a/support/common_sub.rb
+++ b/support/common_sub.rb
@@ -2,8 +2,8 @@
 #
 # common sub function.
 #
-#  Copyright (C) 2015-2022 Kyushu Institute of Technology.
-#  Copyright (C) 2015-2022 Shimane IT Open-Innovation Center.
+#  Copyright (C) 2015- Kyushu Institute of Technology.
+#  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 #
 #  This file is distributed under BSD 3-Clause License.
 #

--- a/support/make_method_table.rb
+++ b/support/make_method_table.rb
@@ -3,8 +3,8 @@
 #
 # create built-in method table include file.
 #
-#  Copyright (C) 2015-2022 Kyushu Institute of Technology.
-#  Copyright (C) 2015-2022 Shimane IT Open-Innovation Center.
+#  Copyright (C) 2015- Kyushu Institute of Technology.
+#  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 #
 #  This file is distributed under BSD 3-Clause License.
 #

--- a/support/make_symbol_table.rb
+++ b/support/make_symbol_table.rb
@@ -2,8 +2,8 @@
 #
 # create built-in symbol table in ROM
 #
-#  Copyright (C) 2015-2022 Kyushu Institute of Technology.
-#  Copyright (C) 2015-2022 Shimane IT Open-Innovation Center.
+#  Copyright (C) 2015- Kyushu Institute of Technology.
+#  Copyright (C) 2015- Shimane IT Open-Innovation Center.
 #
 #  This file is distributed under BSD 3-Clause License.
 #


### PR DESCRIPTION
Remove the end year of the copyright notice.
The start year of most copyright notices was 2015, but only the files in hal were 2016.

Keep it this way, or unify the start year to 2015 ?