### PR TITLE
Symbol literals in VM code will be copied into heap if flag_permanence==1

### DIFF
--- a/src/load.c
+++ b/src/load.c
@@ -199,14 +199,21 @@ static mrbc_irep * load_irep_1(struct VM *vm, const uint8_t *bin, int *len, int 
   // make a sym_id table.
   mrbc_sym *tbl_syms = mrbc_irep_tbl_syms(p_irep);
   for( i = 0; i < irep.slen; i++ ) {
-    int siz = bin_to_uint16(p);	p += 2;
-    mrbc_sym sym = mrbc_str_to_symid( (const char *)p );
+    int siz = bin_to_uint16(p) + 1;	p += 2;
+    char *sym_str;
+    if (vm->flag_permanence == 1) {
+      sym_str = mrbc_raw_alloc_no_free(siz);
+      memcpy(sym_str, p, siz);
+    } else {
+      sym_str = (char *)p;
+    }
+    mrbc_sym sym = mrbc_str_to_symid( (const char *)sym_str );
     if( sym < 0 ) {
       mrbc_raise(vm, MRBC_CLASS(Exception), "Overflow MAX_SYMBOLS_COUNT");
       return NULL;
     }
     *tbl_syms++ = sym;
-    p += (siz+1);
+    p += (siz);
   }
 
   // make a pool data's offset table.


### PR DESCRIPTION
In PicoRuby, the VM code created in RAM is later freed, so symbol literals disappear along with it.
This negatively impacts subsequent behavior, so I wrote this patch