### PR TITLE
Fix return value of c_array_set() and c_string_insert()

### DIFF
--- a/src/c_array.c
+++ b/src/c_array.c
@@ -720,6 +720,8 @@ static void c_array_set(struct VM *vm, mrbc_value v[], int argc)
     if( mrbc_array_set(v, mrbc_integer(v[1]), &v[2]) != 0 ) {
       mrbc_raise( vm, MRBC_CLASS(IndexError), "too small for array");
     }
+    // return val
+    v[0] = v[2];
     mrbc_type(v[2]) = MRBC_TT_EMPTY;
     return;
   }
@@ -760,11 +762,16 @@ static void c_array_set(struct VM *vm, mrbc_value v[], int argc)
       }
     } else {
       mrbc_array_push(&v[0], &v[3]);
-      v[3].tt = MRBC_TT_EMPTY;
     }
 
     mrbc_array_push_m(&v[0], &v1);
     mrbc_array_delete_handle( &v1 );
+
+    // return val
+    v[0] = v[3];
+    if( v[3].tt != MRBC_TT_ARRAY ) {
+      v[3].tt = MRBC_TT_EMPTY;
+    }
     return;
   }
 

--- a/src/c_string.c
+++ b/src/c_string.c
@@ -595,7 +595,7 @@ static void c_string_insert(struct VM *vm, mrbc_value v[], int argc)
 {
   mrbc_int_t nth;
   mrbc_int_t len;
-  const mrbc_value *val;
+  mrbc_value *val;
 
   /*
     in case of self[nth] = val
@@ -649,6 +649,10 @@ static void c_string_insert(struct VM *vm, mrbc_value v[], int argc)
 
   v->string->size = len1 + len2 - len;
   v->string->data = str;
+
+  // return val
+  mrbc_incref(val);
+  v[0] = *val;
 }
 
 

--- a/test/array_test.rb
+++ b/test/array_test.rb
@@ -61,6 +61,30 @@ class ArrayTest < MrubycTestCase
     assert_equal [:AB, :CD, :E], %i(AB CD E)
   end
 
+  description "array.[]=(idx, replace)"
+  def send_aset_case
+    a = [0, 1, 2, 3, 4]
+    assert_equal 9, a.[]=(1, 9)
+    assert_equal [0, 9, 2, 3, 4], a
+
+    b = [0, 1, 2, 3, 4]
+    assert_equal 9, b.[]=(1, 3, 9)
+    assert_equal [0, 9, 4], b
+  end
+
+  description "Array#[idx] = replace (GCed value)"
+  def replace_with_GCed_value_case
+    a = [0,1,2]
+    str = "string"
+    assert_equal str, a[0] = str
+    assert_equal ["string", 1, 2], a
+
+    b = [0,1,2]
+    obj = Object.new
+    assert_equal obj, b[0, 2] = obj
+    assert_equal [obj, 2], b
+  end
+
   description "setter"
   def setter_case
     a = Array.new

--- a/test/string_test.rb
+++ b/test/string_test.rb
@@ -99,6 +99,20 @@ class StringTest < MrubycTestCase
     assert_equal "bar", str0      #(str0 は無傷、 str1 は str0 と内容を共有していない
   end
 
+  description "self[nth]=val -> val"
+  def nth_return_val_case
+    str = "bar"
+    assert_equal "B", str[0] = "B"
+    assert_equal "Bar", str
+  end
+
+  description "send []= case"
+  def send_nth_return_val_case
+    str = "bar"
+    assert_equal "B", str.[]=(0, "B")
+    assert_equal "Bar", str
+  end
+
   description "境界値チェックを詳細にかけておく"
   def boundary_value_case
     s1 = "0123456"


### PR DESCRIPTION
Array and String have the same problem.

Let me show String's case as an example:

## Actual (wrong)

```
array.[]=(idx, replace) → array
array.[]=(idx, len, replace) → array
```

## Expected

```
array.[]=(idx, replace) → replace
array.[]=(idx, len, replace) → replace
```

## Background

As of July 2024, Matz's mrbc compiles `array[0] = 1` as follows:

```
00001 NODE_SCOPE:
00001   NODE_BEGIN:
00001     NODE_ASGN:
00001       lhs:
00001         NODE_CALL(.):
00001           NODE_FCALL:
00001             method='array' (391)
00001           method='[]' (55)
00001           args:
00001             NODE_INT 0 base 10
00001       rhs:
00001         NODE_INT 1 base 10
irep 0x5588e502e530 nregs=6 nlocals=1 pools=0 syms=1 reps=0 ilen=16
file: -
    1 000 SSEND         R2      :array  n=0
    1 004 LOADI_0       R3      (0)
    1 006 LOADI_1       R4      (1)
    1 008 MOVE          R1      R4
    1 011 SETIDX        R2      R3      R4
    1 013 RETURN        R1
    1 015 STOP
```

On the other hand, my new mruby-compiler, leveraging Prism, compiles as follows:

```
@ ProgramNode (location: (1,0)-(1,12))
+-- locals: []
+-- statements:
    @ StatementsNode (location: (1,0)-(1,12))
    +-- body: (length: 1)
        +-- @ CallNode (location: (1,0)-(1,12))
            +-- flags: attribute_write
            +-- receiver:
            |   @ CallNode (location: (1,0)-(1,5))
            |   +-- flags: variable_call, ignore_visibility
            |   +-- receiver: nil
            |   +-- call_operator_loc: nil
            |   +-- name: :array
            |   +-- message_loc: (1,0)-(1,5) = "array"
            |   +-- opening_loc: nil
            |   +-- arguments: nil
            |   +-- closing_loc: nil
            |   +-- block: nil
            +-- call_operator_loc: nil
            +-- name: :[]=
            +-- message_loc: (1,5)-(1,8) = "[0]"
            +-- opening_loc: (1,5)-(1,6) = "["
            +-- arguments:
            |   @ ArgumentsNode (location: (1,6)-(1,12))
            |   +-- flags: nil
            |   +-- arguments: (length: 2)
            |       +-- @ IntegerNode (location: (1,6)-(1,7))
            |       |   +-- flags: decimal
            |       |   +-- value: 0
            |       +-- @ IntegerNode (location: (1,11)-(1,12))
            |           +-- flags: decimal
            |           +-- value: 1
            +-- closing_loc: (1,7)-(1,8) = "]"
            +-- block: nil

irep 0x55d6658091e0 nregs=5 nlocals=1 pools=0 syms=1 reps=0 ilen=13
file: -
      000 SSEND         R1      :array  n=0
      004 LOADI_0       R2      (0)
      006 LOADI_1       R3      (1)
      008 SETIDX        R1      R2      R3
      010 RETURN        R1
      012 STOP
```

### The point

- Matz's parser creates `NODE_ASGN` and `NODE_CALL of []`
- Prism only creates `CALL_NODE of []=`

Accordingly, Matz's compiler generates `OP_MOVE R1 R4` while my new compiler does not (can not because there is no assignment node).

As a result, `OP_MOVE` happened to align the return value correctly, hiding a bug in mruby/c's `c_array_set()`.
(mruby's VM doesn't have the same problem)