### PR TITLE
Allow NULL pointer for mrbc_raw_free() when NDEBUG

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -629,14 +629,16 @@ void * mrbc_raw_alloc_no_free(unsigned int size)
 */
 void mrbc_raw_free(void *ptr)
 {
+  if( ptr == NULL ) {
+#if defined(MRBC_DEBUG)
+    static const char msg[] = "mrbc_raw_free(): NULL pointer was given.\n";
+    hal_write(2, msg, sizeof(msg)-1);
+#endif
+    return;
+  }
+
 #if defined(MRBC_DEBUG)
   {
-    if( ptr == NULL ) {
-      static const char msg[] = "mrbc_raw_free(): NULL pointer was given.\n";
-      hal_write(2, msg, sizeof(msg)-1);
-      return;
-    }
-
     FREE_BLOCK *target = (FREE_BLOCK *)((uint8_t *)ptr - sizeof(USED_BLOCK));
     FREE_BLOCK *block = BLOCK_TOP(memory_pool);
     while( block < (FREE_BLOCK *)BLOCK_END(memory_pool) ) {


### PR DESCRIPTION
## Actual

if you call `mrbc_raw_free(NULL);`, SEGV happens

## Expected

Nothing happens

-----

## Background

In the section 7.20.3.2 of ISO/IEC 9899:1999, `free()` is allowed to be passed NULL:

> If ptr is a null pointer, no action occurs.

See http://www.man6.org/lib/pdfjs/web/viewer.html?file=/blog/PdfFile/c99InternationalStandard.pdf

The above would be why some libraries (eg: ruby/prism) that comply with C99 call the `free()` without NULL-check.

In that case, when MRBC_DEBUG is *undef*, there should be no warning, much less a SEGV.