### PR TITLE
Profile peak memory usage of one process

### DIFF
--- a/src/alloc.h
+++ b/src/alloc.h
@@ -42,6 +42,14 @@ struct MRBC_ALLOC_STATISTICS {
   unsigned int fragmentation;	//!< returns memory fragmentation count.
 };
 
+#if defined(MRBC_USE_ALLOC_PROF)
+struct MRBC_ALLOC_PROF {
+  unsigned long initial;
+  unsigned long max;
+  unsigned long min;
+};
+#endif
+
 struct VM;
 
 /***** Global variables *****************************************************/
@@ -64,6 +72,11 @@ void mrbc_alloc_print_pool_header(void *pool_header);
 void mrbc_alloc_print_memory_block(void *pool_header);
 void mrbc_alloc_print_memory_pool(void);
 
+#if defined(MRBC_USE_ALLOC_PROF)
+void mrbc_alloc_start_profiling(void);
+void mrbc_alloc_stop_profiling(void);
+void mrbc_alloc_get_profiling(struct MRBC_ALLOC_PROF *prof);
+#endif
 
 #if defined(MRBC_ALLOC_VMID)
 // Enables memory management by VMID.


### PR DESCRIPTION
This pull request proposes adding the ~~MRBC_ALLOC_PROFILING~~ MRBC_USE_ALLOC_PROF macro to enable a simple memory profiler.

Public functions defined by ~~MRBC_ALLOC_PROFILING~~ MRBC_USE_ALLOC_PROF are:

- `void mrbc_alloc_start_profiling(void);`
- `void mrbc_alloc_stop_profiling(void);`
- `void mrbc_alloc_get_profiling(struct MRBC_ALLOC_PROF *prof);`

## Difference from `mrbc_alloc_statistics()`

Traditional `mrbc_alloc_statistics()` can measure only memory usage between method calls of the user's application. This means you can not know how memory consumption varies in a method process.

On the other hand, the new `mrbc_alloc_start_profiling()` records the highest memory usage throughout one method call.

I'm proposing this feature separately from MRBC_DEBUG because I'd like to be able to use it in production environments.

## Application in PicoRuby

Building on this feature, PicoRuby can introduce a new `PicoRubyVM.alloc_profile` method. This method reports the peak memory usage within its block. It works like follows:

```ruby
require 'picorubyvm'
require 'json'

json = <<~JSON
  [{"id":"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx","device":{"name":"分電盤の近く","id":"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx","created_at":"2024-09-19T01:08:25Z","updated_at":"2024-09-19T08:53:00Z","mac_address":"xx:xx:xx:xx:xx:xx","bt_mac_address":"xx:xx:xx:xx:xx:xx","serial_number":"123412341234","firmware_version":"Xemo-E-lite/1.10.0","temperature_offset":0,"humidity_offset":0},"model":{"id":"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx","manufacturer":"","name":"Smart Meter","image":"ico_smartmeter"},"type":"EL_SMART_METER","nickname":"スマートメーター","image":"ico_smartmeter","settings":null,"aircon":null,"signals":[],"smart_meter":{"echonetlite_properties":[{"name":"coefficient","epc":211,"val":"1","updated_at":"2024-09-20T01:44:15Z"},{"name":"cumulative_electric_energy_effective_digits","epc":215,"val":"6","updated_at":"2024-09-20T01:44:15Z"},{"name":"normal_direction_cumulative_electric_energy","epc":224,"val":"80481","updated_at":"2024-09-20T01:44:15Z"},{"name":"cumulative_electric_energy_unit","epc":225,"val":"1","updated_at":"2024-09-20T01:44:15Z"},{"name":"reverse_direction_cumulative_electric_energy","epc":227,"val":"9","updated_at":"2024-09-20T01:44:15Z"},{"name":"measured_instantaneous","epc":231,"val":"599","updated_at":"2024-09-20T01:46:14Z"}]}}]
JSON

obj = nil
result = PicoRubyVM.alloc_profile do
  obj = JSON.parse(json)
end
puts "JSON.parse: #{result}"
puts "obj: #{obj.inspect[0,10]}..."

puts

name = nil
result = PicoRubyVM.alloc_profile do
  dig = JSON::Digger.new(json).dig(0, 'smart_meter', 'echonetlite_properties', 0, 'name')
  #                                First element of the array
  #                                -> Value of the key 'smart_meter'
  #                                -> Value of the key 'echonetlite_properties'
  #                                -> First element of the array
  #                                -> Value of the key 'name'
  name = dig.parse
end
puts "JSON::Digger: #{result}"
puts "name: #{name}"
```

Result:

```
JSON.parse: {:peak=>12160, :valley=>0}
obj: [{"id"=>"x...

JSON::Digger: {:peak=>4448, :valley=>0}
name: coefficient
```

`JSON::Digger` extracts specified nodes from the JSON. It is useful when you know the exact structure of the JSON and uses less memory than parsing the whole JSON by `JSON.parse` The example above shows `JSON::Digger#dig` used 4448 bytes and `JSON.parse` used 12160 bytes, approximately 3x.
(see https://github.com/picoruby/picoruby/tree/master/mrbgems/picoruby-json)

## `Object.alloc_profile` ?

I will not propose a Ruby-level wrapper like `Object.alloc_profile` method because I don't like that the Object class has this kind of method.

However, I would not object if the core team were to implement such a method in the Object class.