### PR TITLE
memset should cover the entire size of the vm structure

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -311,10 +311,12 @@ void mrbc_pop_callinfo( struct VM *vm )
 */
 mrbc_vm * mrbc_vm_new( int regs_size )
 {
-  mrbc_vm *vm = mrbc_raw_alloc(sizeof(mrbc_vm) + sizeof(mrbc_value) * regs_size);
+  unsigned int vm_total_size = sizeof(mrbc_vm) + sizeof(mrbc_value) * regs_size;
+
+  mrbc_vm *vm = mrbc_raw_alloc(vm_total_size);
   if( !vm ) return NULL;
 
-  memset(vm, 0, sizeof(mrbc_vm));	// caution: assume NULL is zero.
+  memset(vm, 0, vm_total_size);	// caution: assume NULL is zero.
 #if defined(MRBC_DEBUG)
   memcpy(vm->type, "VM", 2);
 #endif


### PR DESCRIPTION
Otherwise, `mrbc_decref( &vm->regs[0] );` in mrbc_vm_begin https://github.com/mrubyc/mrubyc/blob/release3.3.1/src/vm.c#L397 occasionally causes SEGV (in NDEBUG build)