### PR TITLE
Make mrbc_string_upcase() and mrbc_string_downcase() public

### DIFF
--- a/src/c_string.c
+++ b/src/c_string.c
@@ -369,7 +369,7 @@ int mrbc_string_chomp(mrbc_value *src)
   @param    str     pointer to target value
   @return   count   number of upcased characters
 */
-static int mrbc_string_upcase(mrbc_value *str)
+int mrbc_string_upcase(mrbc_value *str)
 {
   int len = str->string->size;
   int count = 0;
@@ -391,7 +391,7 @@ static int mrbc_string_upcase(mrbc_value *str)
   @param    str     pointer to target value
   @return   count   number of downcased characters
 */
-static int mrbc_string_downcase(mrbc_value *str)
+int mrbc_string_downcase(mrbc_value *str)
 {
   int len = str->string->size;
   int count = 0;

--- a/src/c_string.h
+++ b/src/c_string.h
@@ -67,6 +67,8 @@ int mrbc_string_append_cbuf(mrbc_value *s1, const void *s2, int len2);
 int mrbc_string_index(const mrbc_value *src, const mrbc_value *pattern, int offset);
 int mrbc_string_strip(mrbc_value *src, int mode);
 int mrbc_string_chomp(mrbc_value *src);
+int mrbc_string_upcase(mrbc_value *str);
+int mrbc_string_downcase(mrbc_value *str);
 
 
 /***** Inline functions *****************************************************/


### PR DESCRIPTION
## Use case

In picoruby-mbedtls, I want both `MbedTLS::Cipher.new("AES-256-GCM")` and `MbedTLS::Cipher.new("aes-256-gcm")` to be valid.
It'd be useful if `mrbc_string_upcase()` can be called publicly.
