### PR TITLE
Fix mrbc_raw_realloc()

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -757,6 +757,11 @@ void mrbc_raw_free(void *ptr)
 */
 void * mrbc_raw_realloc(void *ptr, unsigned int size)
 {
+  if (ptr != NULL && size == 0) {
+    mrbc_raw_free(ptr);
+    return NULL;
+  }
+
   MEMORY_POOL *pool = memory_pool;
   volatile USED_BLOCK *target = (USED_BLOCK *)((uint8_t *)ptr - sizeof(USED_BLOCK));
   MRBC_ALLOC_MEMSIZE_T alloc_size = size + sizeof(USED_BLOCK);

--- a/src/c_array.c
+++ b/src/c_array.c
@@ -157,7 +157,6 @@ int mrbc_array_resize(mrbc_value *ary, int size)
   mrbc_array *h = ary->array;
 
   mrbc_value *data2 = mrbc_raw_realloc(h->data, sizeof(mrbc_value) * size);
-  if( !data2 ) return E_NOMEMORY_ERROR;	// ENOMEM
 
   h->data = data2;
   h->data_size = size;


### PR DESCRIPTION
## Summary

I propose to fix `mrbc_raw_realloc(ptr, size);` so that if ptr is not null and size is 0, it fallbacks to `mrbc_raw_free()`.

## Background

Currently, `mrbc_raw_realloc()` returns the minimum size of the chunk. This is compliant with the man realloc(3): https://linux.die.net/man/3/realloc .

However, in the same situation, `realloc()` of glibc behaves as `free()`: see ` __libc_realloc (void *oldmem, size_t bytes)` function of https://sourceware.org/git/?p=glibc.git;a=blob;f=malloc/malloc.c

Due to this inconsistency, mruby/c under the definition of `MRBC_ALLOC_LIBC` crashes in the scenario below:

```ruby
ary = [1]
n = 2      # Any `n` where `ary.size <= n`
ary.pop(n) # It will call `mrbc_array_resize(ary, 0)` and `mrbc_raw_realloc(data, 0)` in turn
           # At this moment, ary.array->data is already freed
p ary      # Invokes `mrbc_decref(array)`
ary = []   # Invokes Another `mrbc_decref(array)`
           # => free(): double free detected in tcache 2
```