### PR TITLE
Fix op_addi and op_subi to make `Time#+(Integer)` work

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -1920,7 +1920,8 @@ static inline void op_addi( mrbc_vm *vm, mrbc_value *regs EXT )
   }
 #endif
 
-  mrbc_raise(vm, MRBC_CLASS(TypeError), "no implicit conversion of Integer");
+  regs[a+1] = mrbc_integer_value(b);
+  send_by_name(vm, MRBC_SYM(PLUS), a, 1);
 }
 
 
@@ -1983,7 +1984,8 @@ static inline void op_subi( mrbc_vm *vm, mrbc_value *regs EXT )
   }
 #endif
 
-  mrbc_raise(vm, MRBC_CLASS(TypeError), "no implicit conversion of Integer");
+  regs[a+1] = mrbc_integer_value(b);
+  send_by_name(vm, MRBC_SYM(MINUS), a, 1);
 }
 
 

--- a/test/addi_subi_test.rb
+++ b/test/addi_subi_test.rb
@@ -1,0 +1,25 @@
+class AddiSubiTest < Picotest::Test
+
+  class AddiSubiTestClass
+  end
+
+  description "In general, Object#+ should raise NoMethodError"
+  def test_no_method_error
+    # PicoRuby's Time#+ and Time#- that take Integer as an argument should work.
+    # Bue we cannot test them in mruby/c
+    assert_raise(NoMethodError) do
+      AddiSubiTestClass.new + 1
+    end
+    assert_raise(NoMethodError) do
+      AddiSubiTestClass.new - 1
+    end
+  end
+
+  description "OP_ADDI and OP_SUBI should in Integer and Float"
+  def test_addi_subi
+    assert_equal 3,   2 + 1
+    assert_equal 3.1, 2.1 + 1
+    assert_equal 1,   2 - 1
+    assert_equal 1.1, 2.1 - 1
+  end
+end


### PR DESCRIPTION
This pull request includes changes to the `src/vm.c` file to modify the behavior of the `op_addi` and `op_subi` functions, as well as the addition of new tests in `test/addi_subi_test.rb` to verify these changes.

## Background

PicoRuby has `Time` class that implements `+` and `-` methods, taking an Integer as an argument. eg):

```
Time.now - 60 #=> returns a time one minute before
```

This patch makes this work.

## Changes to `src/vm.c`:

* Modified the `op_addi` function to set the value of `regs[a+1]` to `mrbc_integer_value(b)` and call `send_by_name` with the `PLUS` symbol instead of raising a `TypeError`.
* Modified the `op_subi` function to set the value of `regs[a+1]` to `mrbc_integer_value(b)` and call `send_by_name` with the `MINUS` symbol instead of raising a `TypeError`.
* `no implicit conversion of Integer (TypeError)` should be implemented in each `+` and `-` method if necessary.

## Addition of new tests:

* Added a new test class `AddiSubiTest` in `test/addi_subi_test.rb` to ensure that `Object#+` raises a `NoMethodError` and to verify the behavior of `OP_ADDI` and `OP_SUBI` with `Integer` and `Float` values.