### PR TITLE
Fix c_object_constants

### DIFF
--- a/src/c_object.c
+++ b/src/c_object.c
@@ -614,6 +614,7 @@ static void c_object_constants(mrb_vm *vm, mrb_value v[], int argc)
 
   while( cls ) {
     cls = mrbc_traverse_class_tree( cls, nest_buf, &nest_idx );
+    if ( !cls ) break;
     if( cls == MRBC_CLASS(Object) ) {
       cls = mrbc_traverse_class_tree_skip( nest_buf, &nest_idx );
       continue;

--- a/test/const_test.rb
+++ b/test/const_test.rb
@@ -49,4 +49,8 @@ class ClassTest1 < Picotest::Test
     assert_equal('Hello from C', MyClass.hello)
   end
 
+  def test_object_constants
+    assert Object.constants.is_a?(Array)
+  end
+
 end


### PR DESCRIPTION
## Actual
- SEGV happens when call `Object.constants`

## Solution
- Add a NULL guard