### PR TITLE
feat: Update test suite to use latest Picotest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Clone PicoRuby
+      run: git clone https://github.com/picoruby/picoruby
+
     - name: Restore Cache
       uses: actions/cache@v3
       with:
@@ -66,7 +69,7 @@ jobs:
               -e MRUBY_CONFIG=default \
               -e RUBY="bin/picoruby" \
               --rm -v ${{ github.workspace }}:/work/mrubyc mrubyc-test \
-              bash -c "rake clean && rake && bin/picoruby /work/mrubyc/test/0_runner.rb"
+              bash -c "rake clean && rake && ruby /work/mrubyc/test/0_runner.rb"
             ;;
           "host_gcc_no_libc")
             docker run \
@@ -76,7 +79,7 @@ jobs:
               -e RUBY="bin/picoruby" \
               -e PICORUBY_NO_LIBC_ALLOC=1 \
               --rm -v ${{ github.workspace }}:/work/mrubyc mrubyc-test \
-              bash -c "rake clean && rake && bin/picoruby /work/mrubyc/test/0_runner.rb"
+              bash -c "rake clean && rake && ruby /work/mrubyc/test/0_runner.rb"
             ;;
           "host_clang")
             docker run \
@@ -85,7 +88,7 @@ jobs:
               -e MRUBY_CONFIG=default \
               -e RUBY="bin/picoruby" \
               --rm -v ${{ github.workspace }}:/work/mrubyc mrubyc-test \
-              bash -c "rake clean && rake && bin/picoruby /work/mrubyc/test/0_runner.rb"
+              bash -c "rake clean && rake && ruby /work/mrubyc/test/0_runner.rb"
             ;;
           "host_clang_no_libc")
             docker run \
@@ -95,7 +98,7 @@ jobs:
               -e RUBY="bin/picoruby" \
               -e PICORUBY_NO_LIBC_ALLOC=1 \
               --rm -v ${{ github.workspace }}:/work/mrubyc mrubyc-test \
-              bash -c "rake clean && rake && bin/picoruby /work/mrubyc/test/0_runner.rb"
+              bash -c "rake clean && rake && ruby /work/mrubyc/test/0_runner.rb"
             ;;
           "arm")
             docker run \
@@ -103,7 +106,7 @@ jobs:
               -e MRUBY_CONFIG=arm-linux-gnueabihf \
               -e RUBY="qemu-arm -L /usr/arm-linux-gnueabihf build/arm-linux-gnueabihf/bin/picoruby" \
               --rm -v ${{ github.workspace }}:/work/mrubyc mrubyc-test \
-              bash -c "rake clean && rake && qemu-arm -L /usr/arm-linux-gnueabihf build/arm-linux-gnueabihf/bin/picoruby /work/mrubyc/test/0_runner.rb"
+              bash -c "rake clean && rake && ruby /work/mrubyc/test/0_runner.rb"
             ;;
           "arm_no_libc")
             docker run \
@@ -112,7 +115,7 @@ jobs:
               -e RUBY="qemu-arm -L /usr/arm-linux-gnueabihf build/arm-linux-gnueabihf/bin/picoruby" \
               -e PICORUBY_NO_LIBC_ALLOC=1 \
               --rm -v ${{ github.workspace }}:/work/mrubyc mrubyc-test \
-              bash -c "rake clean && rake && qemu-arm -L /usr/arm-linux-gnueabihf build/arm-linux-gnueabihf/bin/picoruby /work/mrubyc/test/0_runner.rb"
+              bash -c "rake clean && rake && ruby /work/mrubyc/test/0_runner.rb"
             ;;
           "mips")
             docker run \
@@ -120,7 +123,7 @@ jobs:
               -e MRUBY_CONFIG=mips-linux-gnu \
               -e RUBY="qemu-mips -L /usr/mips-linux-gnu build/mips-linux-gnu/bin/picoruby" \
               --rm -v ${{ github.workspace }}:/work/mrubyc mrubyc-test \
-              bash -c "rake clean && rake && qemu-mips -L /usr/mips-linux-gnu build/mips-linux-gnu/bin/picoruby /work/mrubyc/test/0_runner.rb"
+              bash -c "rake clean && rake && ruby /work/mrubyc/test/0_runner.rb"
             ;;
           "mips_no_libc")
             docker run \
@@ -129,7 +132,13 @@ jobs:
               -e RUBY="qemu-mips -L /usr/mips-linux-gnu build/mips-linux-gnu/bin/picoruby" \
               -e PICORUBY_NO_LIBC_ALLOC=1 \
               --rm -v ${{ github.workspace }}:/work/mrubyc mrubyc-test \
-              bash -c "rake clean && rake && qemu-mips -L /usr/mips-linux-gnu build/mips-linux-gnu/bin/picoruby /work/mrubyc/test/0_runner.rb"
+              bash -c "rake clean && rake && ruby /work/mrubyc/test/0_runner.rb"
             ;;
         esac
       shell: bash
+
+      #    - name: Setup tmate session
+      #      if: ${{ failure() }}
+      #      uses: mxschmitt/action-tmate@v3
+      #      with:
+      #        limit-access-to-actor: true

--- a/Makefile
+++ b/Makefile
@@ -49,9 +49,7 @@ docker_bash_root:
 delete_docker:
 	docker rmi mrubyc-test
 
-.PHONY: test test_host_gcc test_host_clang test_mips test_arm test_host_gcc_no_libc test_host_clang_no_libc test_mips_no_libc test_arm_no_libc test_full
-
-test_full: test_host_gcc test_host_gcc_no_libc test_host_clang test_host_clang_no_libc test_arm test_arm_no_libc test_mips test_mips_no_libc
+.PHONY: test test_all test_host_gcc test_host_clang test_mips test_arm test_host_gcc_no_libc test_host_clang_no_libc test_mips_no_libc test_arm_no_libc
 
 test: # if platform includes darwin, test_clang, else, test_host_gcc
 	@if [ `uname` = "Darwin" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,8 @@ test: # if platform includes darwin, test_clang, else, test_host_gcc
 		make test_host_gcc_no_libc; \
 	fi
 
+test_all: test_host_gcc test_host_gcc_no_libc test_host_clang test_host_clang_no_libc test_arm test_arm_no_libc test_mips test_mips_no_libc
+
 test_arm_no_libc:
 	docker run \
 		-e PICORUBY_DEBUG=1 \
@@ -68,7 +70,7 @@ test_arm_no_libc:
 		-e RUBY="qemu-arm -L /usr/arm-linux-gnueabihf build/arm-linux-gnueabihf/bin/picoruby" \
 		--rm -v $(shell pwd):/work/mrubyc mrubyc-test \
 		bash -c \
-		"rake clean && rake && qemu-arm -L /usr/arm-linux-gnueabihf build/arm-linux-gnueabihf/bin/picoruby /work/mrubyc/test/0_runner.rb"
+		"rake clean && rake && ruby /work/mrubyc/test/0_runner.rb"
 
 test_arm:
 	docker run \
@@ -77,45 +79,49 @@ test_arm:
 		-e RUBY="qemu-arm -L /usr/arm-linux-gnueabihf build/arm-linux-gnueabihf/bin/picoruby" \
 		--rm -v $(shell pwd):/work/mrubyc mrubyc-test \
 		bash -c \
-		"rake clean && rake && qemu-arm -L /usr/arm-linux-gnueabihf build/arm-linux-gnueabihf/bin/picoruby /work/mrubyc/test/0_runner.rb"
+		"rake clean && rake && ruby /work/mrubyc/test/0_runner.rb"
 
 test_host_gcc_no_libc:
 	docker run \
 		-e CC=gcc \
 		-e PICORUBY_DEBUG=1 \
-		-e MRUBY_CONFIG=default \
+		-e MRUBY_CONFIG=picoruby-test \
 		-e PICORUBY_NO_LIBC_ALLOC=1 \
+		-e RUBY="build/host/bin/picoruby" \
 		--rm -v $(shell pwd):/work/mrubyc mrubyc-test \
 		bash -c \
-		"rake clean && rake && bin/picoruby /work/mrubyc/test/0_runner.rb"
+		"rake clean && rake && ruby /work/mrubyc/test/0_runner.rb"
 
 test_host_gcc:
 	docker run \
 		-e CC=gcc \
 		-e PICORUBY_DEBUG=1 \
-		-e MRUBY_CONFIG=default \
+		-e MRUBY_CONFIG=picoruby-test \
+		-e RUBY="build/host/bin/picoruby" \
 		--rm -v $(shell pwd):/work/mrubyc mrubyc-test \
 		bash -c \
-		"rake clean && rake && bin/picoruby /work/mrubyc/test/0_runner.rb"
+		"rake clean && rake && ruby /work/mrubyc/test/0_runner.rb"
 
 test_host_clang_no_libc:
 	docker run \
 		-e CC=clang \
 		-e PICORUBY_DEBUG=1 \
-		-e MRUBY_CONFIG=default \
+		-e MRUBY_CONFIG=picoruby-test \
 		-e PICORUBY_NO_LIBC_ALLOC=1 \
+		-e RUBY="build/host/bin/picoruby" \
 		--rm -v $(shell pwd):/work/mrubyc mrubyc-test \
 		bash -c \
-		"rake clean && rake && bin/picoruby /work/mrubyc/test/0_runner.rb"
+		"rake clean && rake && ruby /work/mrubyc/test/0_runner.rb"
 
 test_host_clang:
 	docker run \
 		-e CC=clang \
 		-e PICORUBY_DEBUG=1 \
-		-e MRUBY_CONFIG=default \
+		-e MRUBY_CONFIG=picoruby-test \
+		-e RUBY="build/host/bin/picoruby" \
 		--rm -v $(shell pwd):/work/mrubyc mrubyc-test \
 		bash -c \
-		"rake clean && rake && bin/picoruby /work/mrubyc/test/0_runner.rb"
+		"rake clean && rake && ruby /work/mrubyc/test/0_runner.rb"
 
 test_mips:
 	docker run -e QEMU_LD_PREFIX=/usr/mips-linux-gnu \
@@ -124,7 +130,7 @@ test_mips:
 		-e RUBY="qemu-mips -L /usr/mips-linux-gnu build/mips-linux-gnu/bin/picoruby" \
 		--rm -v $(shell pwd):/work/mrubyc mrubyc-test \
 		bash -c \
-		"rake clean && rake && qemu-mips build/mips-linux-gnu/bin/picoruby /work/mrubyc/test/0_runner.rb"
+		"rake clean && rake && ruby /work/mrubyc/test/0_runner.rb"
 
 test_mips_no_libc:
 	docker run -e QEMU_LD_PREFIX=/usr/mips-linux-gnu \
@@ -134,4 +140,4 @@ test_mips_no_libc:
 		-e RUBY="qemu-mips -L /usr/mips-linux-gnu build/mips-linux-gnu/bin/picoruby" \
 		--rm -v $(shell pwd):/work/mrubyc mrubyc-test \
 		bash -c \
-		"rake clean && rake && qemu-mips build/mips-linux-gnu/bin/picoruby /work/mrubyc/test/0_runner.rb"
+		"rake clean && rake && ruby /work/mrubyc/test/0_runner.rb"

--- a/test/0_runner.rb
+++ b/test/0_runner.rb
@@ -1,5 +1,5 @@
 # Note:
-#  This script is supporsed to run in CRuby process
+#  This script is supposed to run in CRuby process
 #  while dispached test is running in PicoRuby process.
 
 require File.expand_path('../../picoruby/mrbgems/picoruby-picotest/mrblib/picotest', __FILE__)

--- a/test/0_runner.rb
+++ b/test/0_runner.rb
@@ -1,6 +1,6 @@
 # Note:
 #  This script is supposed to run in CRuby process
-#  while dispached test is running in PicoRuby process.
+#  while dispatched test is running in PicoRuby process.
 
 require File.expand_path('../../picoruby/mrbgems/picoruby-picotest/mrblib/picotest', __FILE__)
 

--- a/test/0_runner.rb
+++ b/test/0_runner.rb
@@ -1,5 +1,9 @@
-require 'picotest'
+# Note:
+#  This script is supporsed to run in CRuby process
+#  while dispached test is running in PicoRuby process.
 
-dir = File.dirname(__FILE__)
+require File.expand_path('../../picoruby/mrbgems/picoruby-picotest/mrblib/picotest', __FILE__)
+
+dir = File.expand_path(File.dirname(__FILE__))
 
 Picotest::Runner.new(dir).run

--- a/test/array_test.rb
+++ b/test/array_test.rb
@@ -336,9 +336,9 @@ class ArrayTest < Picotest::Test
 
   description "uniq test"
   def test_uniq
-    a = %(A B C B)
+    a = %W(A B C B)
     assert_equal %W(A B C), a.uniq
-    assert_equal %(A B C B), a
+    assert_equal %W(A B C B), a
 
     assert_equal %W(A B C), a.uniq!
     assert_equal %W(A B C), a


### PR DESCRIPTION
This commit updates the test infrastructure to be compatible with the latest Picotest framework from the picoruby submodule.

Key changes include:
- Modified  to directly require  gem.
- Updated  and  to use  for executing the test runner script, aligning with Picotest's execution model.
- Adjusted  for host tests to .
- Added  target to  for comprehensive testing.
- Fixed array literal syntax in .