### PR TITLE
Fix hashkey's inspect: "rocket" style to "colon" style

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,16 +50,17 @@ RUN useradd -m -u "$USER_ID" mrubyc
 RUN mkdir /work && chown mrubyc /work
 
 USER mrubyc
-RUN git clone --recursive -b master \
+RUN git clone --depth 1 --recursive -b master \
     https://github.com/picoruby/picoruby /work/picoruby
 
 WORKDIR /work/picoruby
+ENV MRUBY_CONFIG=picoruby-test
 RUN rake --trace
 ENV MRUBY_CONFIG=arm-linux-gnueabihf
 RUN rake --trace
 ENV MRUBY_CONFIG=mips-linux-gnu
 RUN rake --trace
-ENV MRUBY_CONFIG=default
+ENV MRUBY_CONFIG=picoruby-test
 
 VOLUME /work/mrubyc
 

--- a/src/c_hash.c
+++ b/src/c_hash.c
@@ -594,12 +594,18 @@ static void c_hash_inspect(struct VM *vm, mrbc_value v[], int argc)
     if( !flag_first ) mrbc_string_append_cstr( &ret, ", " );
     flag_first = 0;
     mrbc_value *kv = mrbc_hash_i_next(&ite);
+    mrbc_value s1;
 
-    mrbc_value s1 = mrbc_send( vm, v, argc, &kv[0], "inspect", 0 );
-    mrbc_string_append( &ret, &s1 );
-    mrbc_string_delete( &s1 );
-
-    mrbc_string_append_cstr( &ret, "=>" );
+    if (mrbc_type(*kv) == MRBC_TT_SYMBOL) {
+      const char *s = mrbc_symid_to_str(kv->sym_id);
+      mrbc_string_append_cstr( &ret, s );
+      mrbc_string_append_cstr( &ret, ": " );
+    } else {
+      s1 = mrbc_send( vm, v, argc, &kv[0], "inspect", 0 );
+      mrbc_string_append( &ret, &s1 );
+      mrbc_string_delete( &s1 );
+      mrbc_string_append_cstr( &ret, " => " );
+    }
 
     s1 = mrbc_send( vm, v, argc, &kv[1], "inspect", 0 );
     mrbc_string_append( &ret, &s1 );

--- a/src/console.c
+++ b/src/console.c
@@ -95,6 +95,26 @@ static int mrbc_printf_sub_output_arg( mrbc_printf_t *pf, va_list *ap )
   return ret;
 }
 
+/* sub function to print a hashkey
+ */
+static int mrbc_p_sub_hashkey(const mrbc_value *v)
+{
+  switch( mrbc_type(*v) ) {
+    case MRBC_TT_SYMBOL:{
+      const char *s = mrbc_symbol_cstr(v);
+      const char *fmt = strchr(s, ':') ? "\"%s\": " : "%s: ";
+      mrbc_printf(fmt, s);
+      break;
+    }
+    default: {
+      mrbc_p_sub(v);
+      mrbc_print(" => ");
+      break;
+    }
+  }
+  return 0;
+}
+
 
 /***** Global functions *****************************************************/
 
@@ -486,8 +506,7 @@ int mrbc_print_sub(const mrbc_value *v)
     mrbc_hash_iterator ite = mrbc_hash_iterator_new(v);
     while( mrbc_hash_i_has_next(&ite) ) {
       mrbc_value *vk = mrbc_hash_i_next(&ite);
-      mrbc_p_sub(vk);
-      mrbc_print("=>");
+      mrbc_p_sub_hashkey(vk);
       mrbc_p_sub(vk+1);
       if( mrbc_hash_i_has_next(&ite) ) mrbc_print(", ");
     }

--- a/src/symbol.c
+++ b/src/symbol.c
@@ -383,8 +383,17 @@ static void c_symbol_all_symbols(struct VM *vm, mrbc_value v[], int argc)
 static void c_symbol_inspect(struct VM *vm, mrbc_value v[], int argc)
 {
   const char *s = mrbc_symid_to_str( mrbc_symbol(v[0]) );
-  v[0] = mrbc_string_new_cstr(vm, ":");
+  int colon_include = 0;
+  if (strchr(s, ':')) {
+    colon_include = 1;
+    v[0] = mrbc_string_new_cstr(vm, ":\"");
+  } else {
+    v[0] = mrbc_string_new_cstr(vm, ":");
+  }
   mrbc_string_append_cstr(&v[0], s);
+  if (colon_include) {
+    mrbc_string_append_cstr(&v[0], "\"");
+  }
 }
 
 

--- a/test/0_runner.rb
+++ b/test/0_runner.rb
@@ -2,7 +2,7 @@
 #  This script is supposed to run in CRuby process
 #  while dispatched test is running in PicoRuby process.
 
-require File.expand_path('../../picoruby/mrbgems/picoruby-picotest/mrblib/picotest', __FILE__)
+require File.expand_path('../../../picoruby/mrbgems/picoruby-picotest/mrblib/picotest', __FILE__)
 
 dir = File.expand_path(File.dirname(__FILE__))
 

--- a/test/array_test.rb
+++ b/test/array_test.rb
@@ -266,9 +266,9 @@ class ArrayTest < Picotest::Test
     hash = {1=>1, :k2=>:v2, "k3"=>"v3"}
     range = 1..3
     a = [nil, false, true, 123, 2.718, :symbol, array, "string", range, hash]
-    assert_equal %q![nil, false, true, 123, 2.718, :symbol, [1, "AA", :sym], "string", 1..3, {1=>1, :k2=>:v2, "k3"=>"v3"}]!, a.inspect
-    assert_equal %q![nil, false, true, 123, 2.718, :symbol, [1, "AA", :sym], "string", 1..3, {1=>1, :k2=>:v2, "k3"=>"v3"}]!, a.to_s
-    assert_equal %q!,false,true,123,2.718,symbol,1,AA,sym,string,1..3,{1=>1, :k2=>:v2, "k3"=>"v3"}!, a.join(",")
+    assert_equal %q![nil, false, true, 123, 2.718, :symbol, [1, "AA", :sym], "string", 1..3, {1 => 1, k2: :v2, "k3" => "v3"}]!, a.inspect
+    assert_equal %q![nil, false, true, 123, 2.718, :symbol, [1, "AA", :sym], "string", 1..3, {1 => 1, k2: :v2, "k3" => "v3"}]!, a.to_s
+    assert_equal %q!,false,true,123,2.718,symbol,1,AA,sym,string,1..3,{1 => 1, k2: :v2, "k3" => "v3"}!, a.join(",")
   end
 
   description "each"

--- a/test/div_mod_test.rb
+++ b/test/div_mod_test.rb
@@ -1,4 +1,4 @@
-class SymbolTest < Picotest::Test
+class DivModTest < Picotest::Test
 
   description "マイナス値を含む割り算"
   def test_div

--- a/test/symbol_test.rb
+++ b/test/symbol_test.rb
@@ -38,4 +38,9 @@ class SymbolTest < Picotest::Test
     assert_equal "symbol", s.to_s
     assert_not_equal "symbol", s
   end
+
+  description "inspect"
+  def test_inspect
+    assert_equal ':":a"', :":a".inspect
+  end
 end


### PR DESCRIPTION
This pull request introduces several changes to improve the handling of symbols, hash key formatting, and test coverage, as well as minor adjustments to the Dockerfile and test file paths. The most significant updates include enhancements to how symbols and hash keys are represented in `inspect` methods compatible with mruby, particularly in how it formats symbol keys.

ref https://github.com/mruby/mruby/commit/baeeb5e435f49f3abb60a229874aa6a5e1f6b43e

### Enhancements to symbol and hash key handling:

* [`src/c_hash.c`](diffhunk://#diff-3b886b955bc5487ccb99353523de4a29c6ff21135a483777e38a9985b046fe25R597-R608): Updated `c_hash_inspect` to format hash keys differently based on their type (symbol or other types). Symbols are now displayed in a more concise format.
* [`src/console.c`](diffhunk://#diff-83607e903efacec34651dc8ff9f28aaa9f264340760d6f0bf2e4c9365fcd238dR98-R117): Added a helper function `mrbc_p_sub_hashkey` to format hash keys consistently when printing hashes. Updated `mrbc_print_sub` to use this helper function [[1]](diffhunk://#diff-83607e903efacec34651dc8ff9f28aaa9f264340760d6f0bf2e4c9365fcd238dR98-R117) [[2]](diffhunk://#diff-83607e903efacec34651dc8ff9f28aaa9f264340760d6f0bf2e4c9365fcd238dL489-R509).
* [`src/symbol.c`](diffhunk://#diff-fde072e4f08c38fabaeac5c8eebfb97d8235ba915a37d1904ff2cc4e89f56bc5R386-R396): Modified `c_symbol_inspect` to include quotes around symbols with colons, improving their readability.

### Updates to test cases:

* [`test/array_test.rb`](diffhunk://#diff-64b0cb996b760a49aa4609158527abf3e4906109591bfe5540b8cba9efb9916aL269-R271): Adjusted expected outputs in `test_inspect` to reflect the updated formatting of hash keys and symbols.
* [`test/symbol_test.rb`](diffhunk://#diff-2fecb75b776552a14162f3e2ae8ddd573c9e566405cd5a5a5791f0441c0bc75bR41-R45): Added a new test case for the `inspect` method to verify the formatting of symbols with colons.
* [`test/div_mod_test.rb`](diffhunk://#diff-c3979cf0b311363949bb2c9eca1c8c4b57dc77c38d959c719bfa3f67f0a23424L1-R1): Renamed the test class from `SymbolTest` to `DivModTest` for clarity.

### Dockerfile improvements:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L53-R63): Changed the `git clone` command to use `--depth 1` for a shallow clone, reducing download size. Updated default `MRUBY_CONFIG` to `picoruby-test` for consistency.

### Test file path adjustment:

* [`test/0_runner.rb`](diffhunk://#diff-0944371de183748e94fc59277669cf662d2f096eada8de5db0bbe1f3496dbe80L5-R5): Fixed the file path to `picotest` to ensure compatibility with the directory structure.