### PR TITLE
Fix potential memory leak

### DIFF
--- a/sample_c/sample_concurrent.c
+++ b/sample_c/sample_concurrent.c
@@ -57,7 +57,11 @@ int main(int argc, char *argv[])
     fprintf( stderr, "Loading: '%s'\n", argv[i+1] );
     uint8_t *mrbbuf = load_mrb_file( argv[i+1] );
     if( mrbbuf == 0 ) return 1;
-    if( !mrbc_create_task( mrbbuf, NULL ) ) return 1;
+    if( !mrbc_create_task( mrbbuf, NULL ) ) {
+      free(mrbbuf);
+      return 1;
+    }
+    free(mrbbuf);
   }
 
   // and execute all.

--- a/sample_c/sample_myclass.c
+++ b/sample_c/sample_myclass.c
@@ -76,7 +76,11 @@ int main(int argc, char *argv[])
   mrbc_define_method(0, my_cls, "method1", c_myclass_method1);
 
 
-  if( !mrbc_create_task(mrbbuf, NULL) ) return 1;
+  if( !mrbc_create_task(mrbbuf, NULL) ) {
+    free(mrbbuf);
+    return 1;
+  } 
+  free(mrbbuf);
   int ret = mrbc_run();
 
   /*

--- a/sample_c/sample_no_scheduler.c
+++ b/sample_c/sample_no_scheduler.c
@@ -61,11 +61,13 @@ int main(int argc, char *argv[])
   mrbc_vm *vm = mrbc_vm_open(NULL);
   if( vm == NULL ) {
     fprintf(stderr, "Error: Can't assign VM.\n");
+    free(mrbbuf);
     return 1;
   }
 
   if( mrbc_load_mrb(vm, mrbbuf) != 0 ) {
     mrbc_print_exception(&vm->exception);
+    free(mrbbuf);
     return 1;
   }
 
@@ -73,6 +75,7 @@ int main(int argc, char *argv[])
   int ret = mrbc_vm_run( vm );
   mrbc_vm_end( vm );
   mrbc_vm_close( vm );
+  free(mrbbuf);
 
   /*
     Done

--- a/sample_c/sample_scheduler.c
+++ b/sample_c/sample_scheduler.c
@@ -54,7 +54,12 @@ int main(int argc, char *argv[])
     start mruby/c with rrt0 scheduler.
   */
   mrbc_init(memory_pool, MRBC_MEMORY_SIZE);
-  if( !mrbc_create_task(mrbbuf, NULL) ) return 1;
+  if( !mrbc_create_task(mrbbuf, NULL) ) {
+    free(mrbbuf);
+    return 1;
+  }
+  free(mrbbuf);
+
   int ret = mrbc_run();
 
   /*


### PR DESCRIPTION
Regarding the `load_mrb_file` function: it allocates memory via malloc, but this memory is not freed in the main function. I have submitted a pull request to address this oversight.
While the program is relatively simple and the operating system will reclaim all resources once the program exits, fixing this issue is still worthwhile. It demonstrates better programming practices—an important consideration for code in the `sample_c` folder, where example code should serve as a clear, high-quality reference.

```c
uint8_t * load_mrb_file(const char *filename)
{
  FILE *fp = fopen(filename, "rb");

  if( fp == NULL ) {
    fprintf(stderr, "File not found (%s)\n", filename);
    return NULL;
  }

  // get filesize
  fseek(fp, 0, SEEK_END);
  size_t size = ftell(fp);
  fseek(fp, 0, SEEK_SET);

  // allocate memory
  uint8_t *p = malloc(size);  // =================== allocate memory here.
  if( p != NULL ) {
    fread(p, sizeof(uint8_t), size, fp);
  } else {
    fprintf(stderr, "Memory allocate error.\n");
  }
  fclose(fp);

  return p;
}
```