### PR TITLE
Adding a check for MRBC_TIMESLICE_TICK_COUNT > 0.

### DIFF
--- a/src/rrt0.c
+++ b/src/rrt0.c
@@ -29,6 +29,9 @@
 
 #define MRBC_MUTEX_TRACE(...) ((void)0)
 
+#if !defined(MRBC_TIMESLICE_TICK_COUNT) || (MRBC_TIMESLICE_TICK_COUNT <= 0)
+#error "MRBC_TIMESLICE_TICK_COUNT must be a natural number."
+#endif
 
 /***** Typedefs *************************************************************/
 /***** Function prototypes **************************************************/
@@ -372,7 +375,7 @@ int mrbc_run(void)
     tcb->vm.flag_preemption = 0;
 #else
     // Emulate time slice preemption.
-    int ret_vm_run;
+    int ret_vm_run = 0;
     tcb->vm.flag_preemption = 1;
     while( tcb->timeslice != 0 ) {
       ret_vm_run = mrbc_vm_run( &tcb->vm );


### PR DESCRIPTION
This PR adds a check to ensure `MRBC_TIMESLICE_TICK_COUNT` is greater than 0.  
`MRBC_TIMESLICE_TICK_COUNT` defines the time slice for task switching.  
If this value is zero or less, no tasks are executed and the VM falls into an infinite task-switching loop.

# Changes
I added a preprocessor check for `MRBC_TIMESLICE_TICK_COUNT` in `rrt0.c`.  
```
#if !defined(MRBC_TIMESLICE_TICK_COUNT) || (MRBC_TIMESLICE_TICK_COUNT <= 0)
#error "MRBC_TIMESLICE_TICK_COUNT must be a natural number."
#endif
```

I initialized `ret_vm_run` in `rrt0.c` to prevent compiler warnings.  

# Background
I am using mruby/c with ESP-IDF SDK on the ESP32 microcontroller.  
By default, ESP-IDF compiles with `-Werror=maybe-uninitialized`.   
Thus, the compilation fails with the following message:  
```
mrubyc/src/rrt0.c:389:7: error: 'ret_vm_run' may be used uninitialized [-Werror=maybe-uninitialized]
  389 |     if( ret_vm_run != 0 ) {
      |       ^
mrubyc/src/rrt0.c:375:9: note: 'ret_vm_run' was declared here
  375 |     int ret_vm_run;
      |         ^~~~~~~~~~
```
While `ret_vm_run` is intended to be assigned during execution, the compiler cannot recognize it.  
https://github.com/mrubyc/mrubyc/blob/232e08cd0382aa0ddd3d6e4d46f9828991ccf5de/src/rrt0.c#L366-L384
To resolve this, I have ensured that `MRBC_TIMESLICE_TICK_COUNT` (and consequently `tcb->timeslice`) must be greater than 0, guaranteeing the loop's execution.  
I have also explicitly initialized `ret_vm_run` to avoid this error/warning.