### PR TITLE
Fix NULL pointer dereference on out-of-memory (issue #247)

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -561,8 +561,9 @@ void * mrbc_raw_alloc(unsigned int size)
 #else
   static const char msg[] = "Fatal error: Out of memory.\n";
   hal_write(2, msg, sizeof(msg)-1);
+  hal_abort(0);
 #endif
-  return NULL;  // ENOMEM
+  return NULL;  // ENOMEM (unreachable if hal_abort doesn't return)
 
 
  FOUND_FLI_SLI:

--- a/src/load.c
+++ b/src/load.c
@@ -208,6 +208,7 @@ static mrbc_irep * load_irep_1(struct VM *vm, const uint8_t *bin, int *len)
     char *sym_str;
     if (vm->flag_permanence == 1) {
       sym_str = mrbc_raw_alloc_no_free(siz);
+      if( !sym_str ) return NULL;  // ENOMEM
       memcpy(sym_str, p, siz);
     } else {
       sym_str = (char *)p;

--- a/src/vm.c
+++ b/src/vm.c
@@ -2285,7 +2285,7 @@ static inline void op_arycat( mrbc_vm *vm, mrbc_value *regs EXT )
 
   // need resize?
   if( regs[a].array->data_size < new_size ) {
-    mrbc_array_resize(&regs[a], new_size);
+    if( mrbc_array_resize(&regs[a], new_size) != 0 ) return;  // ENOMEM
   }
 
   for( int i = 0; i < size_2; i++ ) {

--- a/src/vm_config.h
+++ b/src/vm_config.h
@@ -126,7 +126,9 @@
 // Nesting level for exception printing (default 8)
 // #define MRBC_EXCEPTION_CALL_NEST_LEVEL 8
 
-// Examples of override actions when some fatal errors.
+// Override actions when some fatal errors.
+// Default behavior for MRBC_OUT_OF_MEMORY is to print error and call hal_abort().
+// Uncomment and customize if you need different behavior:
 // #define MRBC_OUT_OF_MEMORY() mrbc_alloc_print_memory_pool(); hal_abort(0)
 // #define MRBC_ABORT_BY_EXCEPTION(vm) mrbc_p( &vm->exception ); hal_abort(0)
 


### PR DESCRIPTION
When memory allocation fails, `mrbc_raw_alloc_no_free()` could return `NULL` which was then used without checking, causing a crash in memcpy.

Changes:
- `alloc.c`: Add `hal_abort()` to default OOM handler to halt the VM instead of returning `NULL` and causing undefined behavior
- `load.c`: Add defensive `NULL` check before `memcpy` (original bug location)
- `vm.c`: Add return value check for `mrbc_array_resize` in `op_arycat`
- `vm_config.h`: Update documentation about default OOM behavior

This implements the fail-safe approach suggested by @kaz0505: on embedded systems, OOM represents a critical failure and halting is safer than attempting recovery with potentially corrupted state.

Fixes: mrubyc/mrubyc#247