### PR TITLE
Fix build config for host

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,7 @@ jobs:
             docker run \
               -e CC=gcc \
               -e PICORUBY_DEBUG=1 \
-              -e MRUBY_CONFIG=default \
+              -e MRUBY_CONFIG=picoruby-test \
               -e RUBY="bin/picoruby" \
               --rm -v ${{ github.workspace }}:/work/mrubyc mrubyc-test \
               bash -c "rake clean && rake && ruby /work/mrubyc/test/0_runner.rb"
@@ -75,7 +75,7 @@ jobs:
             docker run \
               -e CC=gcc \
               -e PICORUBY_DEBUG=1 \
-              -e MRUBY_CONFIG=default \
+              -e MRUBY_CONFIG=picoruby-test \
               -e RUBY="bin/picoruby" \
               -e PICORUBY_NO_LIBC_ALLOC=1 \
               --rm -v ${{ github.workspace }}:/work/mrubyc mrubyc-test \
@@ -85,7 +85,7 @@ jobs:
             docker run \
               -e CC=clang \
               -e PICORUBY_DEBUG=1 \
-              -e MRUBY_CONFIG=default \
+              -e MRUBY_CONFIG=picoruby-test \
               -e RUBY="bin/picoruby" \
               --rm -v ${{ github.workspace }}:/work/mrubyc mrubyc-test \
               bash -c "rake clean && rake && ruby /work/mrubyc/test/0_runner.rb"
@@ -94,7 +94,7 @@ jobs:
             docker run \
               -e CC=clang \
               -e PICORUBY_DEBUG=1 \
-              -e MRUBY_CONFIG=default \
+              -e MRUBY_CONFIG=picoruby-test \
               -e RUBY="bin/picoruby" \
               -e PICORUBY_NO_LIBC_ALLOC=1 \
               --rm -v ${{ github.workspace }}:/work/mrubyc mrubyc-test \


### PR DESCRIPTION
This pull request updates the test workflow configuration to use the `picoruby-test` mruby configuration instead of the default for all relevant Docker test runs. This ensures that tests are executed with the correct settings tailored for the PicoRuby environment.

**CI/CD workflow configuration:**

* Updated all Docker test commands in `.github/workflows/test.yml` to set the `MRUBY_CONFIG` environment variable to `picoruby-test` instead of `default`, ensuring tests run under the intended configuration. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L69-R69) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L78-R78) [[3]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L88-R88) [[4]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L97-R97)