### PR TITLE
RP2040 HAL: Define methods when `MRBC_NO_TIMER` is defined

### DIFF
--- a/hal/rp2040/hal.c
+++ b/hal/rp2040/hal.c
@@ -55,6 +55,9 @@ void hal_init(void){
                         | CLOCKS_SLEEP_EN1_CLK_PERI_UART0_BITS;
 }
 
+#endif /* ifndef MRBC_NO_TIMER */
+
+
 //================================================================
 /*!@brief
   Write
@@ -94,9 +97,6 @@ int hal_write(int fd, const void *buf, int nbytes)
 int hal_flush(int fd) {
   return 0;
 }
-
-#endif /* ifndef MRBC_NO_TIMER */
-
 
 //================================================================
 /*!@brief


### PR DESCRIPTION
Move `#endif` in `hal/rp2040/hal.c` to right after `hal_init()` so that `hal_write` / `hal_flush` are always defined regardless of `MRBC_NO_TIMER`.

Fixes #270