### PR TITLE
Support rest parameters in implicit super

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -1430,15 +1430,12 @@ static inline void op_argary( mrbc_vm *vm, mrbc_value *regs EXT )
   FETCH_BS();
 
   int m1 = (b >> 11) & 0x3f;
+  int r  = (b >> 10) & 0x01;
+  int m2 = (b >>  5) & 0x1f;
   int d  = (b >>  4) & 0x01;
   int lv = b & 0x0f;
 
-  if( b & 0x400 ) {	// check REST parameter.
-    // TODO: want to support.
-    mrbc_raise( vm, MRBC_CLASS(NotImplementedError), "Not support rest parameter by super");
-    return;
-  }
-  if( b & 0x3e0 ) {	// check m2 parameter.
+  if( m2 ) {
     mrbc_raise( vm, MRBC_CLASS(NotImplementedError), "not support m2 argument");
     return;
   }
@@ -1463,13 +1460,26 @@ static inline void op_argary( mrbc_vm *vm, mrbc_value *regs EXT )
   }
 
   // create argument array.
-  int array_size = m1 + d;
-  mrbc_value argary = mrbc_array_new( vm, array_size );
+  int rest_len = 0;
+  mrbc_value *rest_data = NULL;
+  if( r && mrbc_type(reg0[m1+1]) == MRBC_TT_ARRAY ) {
+    rest_len = mrbc_array_size(&reg0[m1+1]);
+    rest_data = reg0[m1+1].array->data;
+  }
+
+  mrbc_value argary = mrbc_array_new( vm, m1 + rest_len + m2 );
 
   for( int i = 1; i <= m1; i++ ) {
     mrbc_incref( &reg0[i] );
     mrbc_array_push( &argary, &reg0[i] );
   }
+
+  for( int i = 0; i < rest_len; i++ ) {
+    mrbc_incref( &rest_data[i] );
+    mrbc_array_push( &argary, &rest_data[i] );
+  }
+
+  int block_reg = m1 + r + m2;
 
   if( d ) {
     if( !callinfo ) callinfo = vm->callinfo_tail;
@@ -1477,6 +1487,7 @@ static inline void op_argary( mrbc_vm *vm, mrbc_value *regs EXT )
     mrbc_value karg = mrbc_immediate_value(MRBC_TT_HASH, .hash = callinfo->karg_keep);
     karg = mrbc_hash_dup(vm, &karg);
     mrbc_array_push( &argary, &karg );
+    block_reg++;
   }
 
   mrbc_decref( &regs[a] );
@@ -1484,7 +1495,7 @@ static inline void op_argary( mrbc_vm *vm, mrbc_value *regs EXT )
 
   // copy a block object
   mrbc_decref( &regs[a+1] );
-  regs[a+1] = reg0[array_size+1];
+  regs[a+1] = reg0[block_reg+1];
   mrbc_incref( &regs[a+1] );
 }
 

--- a/test/my_super_test.rb
+++ b/test/my_super_test.rb
@@ -52,4 +52,112 @@ class MySuperTest < Picotest::Test
     assert_equal 2222, obj.a2
   end
 
+  # super with rest parameters
+
+  class MySuperRest0
+    attr_reader :name, :args
+
+    def initialize( name, *args )
+      @name = name
+      @args = args
+    end
+
+    def method1( prefix, *words )
+      [prefix, *words].join(" ")
+    end
+  end
+
+  class MySuperRest1 < MySuperRest0
+    def initialize( name, *args )
+      super
+    end
+
+    def method1( prefix, *words )
+      super
+    end
+  end
+
+  description "super with rest params (initialize)"
+  def test_super_rest_init
+    obj = MySuperRest1.new("Rex", "a", "b")
+    assert_equal "Rex", obj.name
+    assert_equal ["a", "b"], obj.args
+  end
+
+  description "super with rest params (no extra args)"
+  def test_super_rest_empty
+    obj = MySuperRest1.new("Buddy")
+    assert_equal "Buddy", obj.name
+    assert_equal [], obj.args
+  end
+
+  description "super with rest params (method)"
+  def test_super_rest_method
+    obj = MySuperRest1.new("Rex")
+    assert_equal "hello world foo", obj.method1("hello", "world", "foo")
+  end
+
+  # super with optional + rest parameters
+
+  class MySuperOptRest0
+    attr_reader :a, :b, :rest
+
+    def initialize( a, b = 10, *rest )
+      @a = a
+      @b = b
+      @rest = rest
+    end
+  end
+
+  class MySuperOptRest1 < MySuperOptRest0
+    def initialize( a, b = 10, *rest )
+      super
+    end
+  end
+
+  description "super with optional + rest params"
+  def test_super_opt_rest
+    obj = MySuperOptRest1.new(1, 2, 3, 4)
+    assert_equal 1, obj.a
+    assert_equal 2, obj.b
+    assert_equal [3, 4], obj.rest
+  end
+
+  description "super with optional + rest params (defaults)"
+  def test_super_opt_rest_defaults
+    obj = MySuperOptRest1.new(1)
+    assert_equal 1, obj.a
+    assert_equal 10, obj.b
+    assert_equal [], obj.rest
+  end
+
+  # super with rest params inside a block
+
+  class MySuperBlock0
+    attr_reader :args
+    def initialize( *args )
+      @args = args
+    end
+  end
+
+  class MySuperBlock1 < MySuperBlock0
+    def initialize( *args )
+      [1].each do
+        super
+      end
+    end
+  end
+
+  description "super with rest params inside a block"
+  def test_super_rest_block
+    obj = MySuperBlock1.new("x", "y")
+    assert_equal ["x", "y"], obj.args
+  end
+
+  description "super with empty rest params inside a block"
+  def test_super_rest_block_empty
+    obj = MySuperBlock1.new
+    assert_equal [], obj.args
+  end
+
 end


### PR DESCRIPTION
## Summary

Implicit `super` (without arguments) did not work when the method had rest parameters (`*args`). It raised `NotImplementedError: Not support rest parameter by super`.

### How to reproduce

```ruby
class Animal
  def initialize(name, *sounds)
    @name = name
    @sounds = sounds
  end
end

class Dog < Animal
  def initialize(name, *sounds)
    super  # => NotImplementedError
  end
end
```

Using `super(name, *sounds)` (explicit) worked fine -- only the implicit form was broken.

### Fix

Updated `op_argary` in `vm.c` to unpack the rest array into the argument list, similar to how mruby handles it. The change is small:

- Parse the `r` (rest) flag from the ARGARY operand
- If set, read the rest array from its register and push each element into the argument array
- Correctly calculate the block register position

### Tests

Added 7 test methods to `my_super_test.rb`:

- `super` with rest params (with args, no args, single arg)
- `super` with optional + rest params (with values, with defaults)
- `super` with rest params inside a block

All 1521 tests pass (host_gcc).

Thank you!