### PR TITLE
Use single-precision functions for mrbc_float_t paths when MRBC_USE_FLOAT=1

### DIFF
--- a/src/c_numeric.c
+++ b/src/c_numeric.c
@@ -28,6 +28,11 @@
 
 /***** Constat values *******************************************************/
 /***** Macros ***************************************************************/
+#if MRBC_USE_FLOAT == 1
+#define MRBC_POW powf
+#else
+#define MRBC_POW pow
+#endif
 /***** Typedefs *************************************************************/
 /***** Function prototypes **************************************************/
 /***** Local variables ******************************************************/
@@ -86,7 +91,7 @@ static void c_integer_power(mrbc_vm *vm, mrbc_value v[], int argc)
 
 #if MRBC_USE_FLOAT && MRBC_USE_MATH
   else if( mrbc_type(v[1]) == MRBC_TT_FLOAT ) {
-    SET_FLOAT_RETURN( pow( mrbc_integer(v[0]), mrbc_float(v[1])));
+    SET_FLOAT_RETURN( MRBC_POW( mrbc_integer(v[0]), mrbc_float(v[1])));
   }
 #endif
 }
@@ -430,7 +435,7 @@ static void c_float_power(mrbc_vm *vm, mrbc_value v[], int argc)
   default:					break;
   }
 
-  SET_FLOAT_RETURN( pow( mrbc_float(v[0]), n ));
+  SET_FLOAT_RETURN( MRBC_POW( mrbc_float(v[0]), n ));
 }
 #endif
 

--- a/src/c_string.c
+++ b/src/c_string.c
@@ -900,7 +900,11 @@ static void c_string_to_i(mrbc_vm *vm, mrbc_value v[], int argc)
 */
 static void c_string_to_f(mrbc_vm *vm, mrbc_value v[], int argc)
 {
-  mrbc_float_t d = atof(mrbc_string_cstr(v));
+#if MRBC_USE_FLOAT == 1
+  mrbc_float_t d = strtof(mrbc_string_cstr(v), NULL);
+#else
+  mrbc_float_t d = strtod(mrbc_string_cstr(v), NULL);
+#endif
 
   SET_FLOAT_RETURN( d );
 }

--- a/src/value.h
+++ b/src/value.h
@@ -280,7 +280,7 @@ typedef struct RObject mrb_value;	// not recommended.
   (val).tt == MRBC_TT_FLOAT ? (mrbc_int_t)(val).d : 0
 #define MRBC_TO_FLOAT(val) \
   (val).tt == MRBC_TT_FLOAT ? (val).d : \
-  (val).tt == MRBC_TT_INTEGER ? (mrbc_float_t)(val).i : 0.0
+  (val).tt == MRBC_TT_INTEGER ? (mrbc_float_t)(val).i : (mrbc_float_t)0
 
 #endif  // !defined(MRBC_NOT_RECOMMEND_TO_USE)
 


### PR DESCRIPTION
## Summary

This PR makes selected floating-point code paths use `mrbc_float_t` more consistently when `MRBC_USE_FLOAT=1`.

Changes included:

- Use `powf()` instead of `pow()` for numeric power operations when `MRBC_USE_FLOAT == 1`.
- Use `strtof()` instead of `atof()` for `String#to_f` when `MRBC_USE_FLOAT == 1`.
- Use `(mrbc_float_t)0` instead of `0.0` in `MRBC_TO_FLOAT()` to avoid introducing a `double` literal into the conditional expression.
- Intentionally leave the `Math` class unchanged for Ruby compatibility.

For `MRBC_USE_FLOAT=2`, the code continues to use double-precision functions where appropriate, such as `pow()` and `strtod()`.

## Motivation

When `MRBC_USE_FLOAT=1`, `mrbc_float_t` is intended to be a single-precision floating-point type.

However, some code paths still used double-oriented C constructs:

- `pow()` returns `double`.
- `atof()` returns `double`.
- `0.0` is a `double` literal.

On embedded targets, these can introduce unnecessary float/double conversions or double-precision helper calls even when the build is configured for single-precision floats.

This matters especially on MCUs with a single-precision FPU, where single-precision operations can be handled efficiently by hardware while double-precision operations may be more expensive.

## Compatibility note about the Math class

This PR intentionally does not modify the `Math` class.

The `Math` class is compatibility-sensitive because it corresponds to Ruby's standard `Math` API. This PR is limited to selected code paths where mruby/c already stores or returns values as `mrbc_float_t`, such as:

- numeric power operations
- `String#to_f`
- `MRBC_TO_FLOAT()`

In other words, this PR is not a mechanical replacement of all double-based C library calls.

The goal is to avoid unnecessary double-precision conversions in selected `mrbc_float_t` paths for `MRBC_USE_FLOAT=1`, while leaving Ruby compatibility-sensitive `Math` behavior unchanged.

## Test environment

The benchmark below was run on a Nordic nRF54L15 target.

- The nRF54L15 uses an Arm Cortex-M33 processor running at 128 MHz.
- The nRF54L15's CPU as having a single-precision floating-point unit (FPU).

Build/runtime configuration:
 
- Target: Nordic nRF54L15 (Arm Cortex-M33 with FPU)
- Tested with both:
  - `MRBC_USE_FLOAT=1`
  - `MRBC_USE_FLOAT=2`
- mruby/c version: release3.4.1

## Benchmark summary

The benchmark checks whether runtime behavior matches single-precision or double-precision floating-point behavior, then runs simple arithmetic loops.

### MRBC_USE_FLOAT=1

Precision behavior was unchanged: both before and after this PR, the runtime behaved as single-precision float.

Performance improved in this environment:

| Benchmark | Before ops/tick | After ops/tick | Change |
| --- | ---: | ---: | ---: |
| Float Addition | 39.42 | 41.47 | +5.2% |
| Float Multiplication | 39.37 | 41.42 | +5.2% |
| Float Division | 38.88 | 41.32 | +6.3% |
| Mixed Operations | 34.86 | 36.79 | +5.5% |

### MRBC_USE_FLOAT=2

Precision behavior was unchanged: both before and after this PR, the runtime behaved as double-precision float.

The `MRBC_USE_FLOAT=2` results are included as a reference. This PR mainly targets unnecessary double-precision conversions in `MRBC_USE_FLOAT=1` builds.

| Benchmark | Before ops/tick | After ops/tick |
| --- | ---: | ---: |
| Float Addition | 40.56 | 39.26 |
| Float Multiplication | 42.22 | 41.09 |
| Float Division | 34.79 | 34.02 |
| Mixed Operations | 34.37 | 33.59 |

## Benchmark script

The following script was used for the benchmark.

<details>
<summary>Benchmark Ruby script</summary>

```ruby
# Float/Double Precision & Performance Benchmark
# Runs once, prints results, then ends the task

sleep 3

# Print runtime info
printf "=== Float/Double Benchmark ===\n"
printf "#{RUBY_ENGINE} #{MRUBYC_VERSION} (mruby:#{MRUBY_VERSION} ruby:#{RUBY_VERSION})\n"

# ============== Precision Checks ==============
# These expressions show different results for float vs double

float_matches = 0
double_matches = 0

# Case 1: Large number + small number (float loses precision)
a = 16_777_216.0  # 2^24
b = 1.0
result = a + b
match_float = (result == a)
match_double = (result > a)
if match_float
  float_matches = float_matches + 1
end
if match_double
  double_matches = double_matches + 1
end

printf "\n--- Precision Check 1: Large + Small ---\n"
printf "Expression: 16777216.0 + 1.0\n"
printf "Actual result: %.1f\n", result
printf "Float-equivalent expected: 16777216.0\n"
printf "Double-equivalent expected: 16777217.0\n"
printf "Match float: %s\n", match_float ? "YES" : "NO"
printf "Match double: %s\n", match_double ? "YES" : "NO"

# Case 2: Cancellation (sensitive test)
x = 16_777_216.0
y = x + 1.0
result2 = y - x
match_float = (result2 == 0.0)
match_double = (result2 == 1.0)
if match_float
  float_matches = float_matches + 1
end
if match_double
  double_matches = double_matches + 1
end

printf "\n--- Precision Check 2: Cancellation ---\n"
printf "Expression: (16777216.0 + 1.0) - 16777216.0\n"
printf "Actual result: %.1f\n", result2
printf "Float-equivalent expected: 0.0\n"
printf "Double-equivalent expected: 1.0\n"
printf "Match float: %s\n", match_float ? "YES" : "NO"
printf "Match double: %s\n", match_double ? "YES" : "NO"

# Case 3: High precision decimal
result3 = 0.1 + 0.2
threshold3 = 0.3
match_float = (result3 == threshold3)
match_double = (result3 > threshold3)
if match_float
  float_matches = float_matches + 1
end
if match_double
  double_matches = double_matches + 1
end

printf "\n--- Precision Check 3: 0.1 + 0.2 ---\n"
printf "Actual result: %.17f\n", result3
printf "Float-equivalent expected: 0.30000001192092896\n"
printf "Double-equivalent expected: 0.30000000000000004\n"
printf "Match float: %s\n", match_float ? "YES" : "NO"
printf "Match double: %s\n", match_double ? "YES" : "NO"

printf "\n--- Precision Summary ---\n"
printf "Float-behavior matches: %d/3\n", float_matches
printf "Double-behavior matches: %d/3\n", double_matches
if float_matches > double_matches
  printf "Detected precision: float\n"
elsif double_matches > float_matches
  printf "Detected precision: double\n"
else
  printf "Detected precision: inconclusive\n"
end

# ============== Performance Benchmarks ==============
printf "\n--- Performance Benchmarks ---\n"
ITERATIONS = 1000000

# Helper to measure time
def benchmark(name, iterations)
  start_tick = VM.tick
  
  i = 0
  while i < iterations
    yield
    i = i + 1
  end
  
  end_tick = VM.tick
  elapsed = end_tick - start_tick
  
  printf "\n%s:\n", name
  printf "  Iterations: %d\n", iterations
  printf "  Elapsed ticks: %d\n", elapsed
  if elapsed > 0
    ops_per_tick = iterations.to_f / elapsed.to_f
    printf "  Ops per tick: %.2f\n", ops_per_tick
  else
    printf "  Ops per tick: N/A (too fast to measure)\n"
  end
end

# Addition benchmark
benchmark("Float Addition", ITERATIONS) do
  sum = 1.23456789
  sum = sum + 0.00000001
end

# Multiplication benchmark
benchmark("Float Multiplication", ITERATIONS) do
  prod = 1.23456789
  prod = prod * 1.00000001
end

# Division benchmark
benchmark("Float Division", ITERATIONS) do
  quot = 123456789.0
  quot = quot / 1.00000001
end

# Mixed operations benchmark
benchmark("Mixed Operations", ITERATIONS) do
  val = 1.0
  val = (val + 0.5) * 2.0 / 3.0
end

# Summary
printf "\n=== Benchmark Complete ===\n"
```

</details>

## Full benchmark output

<details>
<summary>Before this PR: MRBC_USE_FLOAT=1</summary>

```console
=== Float/Double Benchmark ===
mruby/c 3.4 (mruby:3.4.0 ruby:3.4)
--- Precision Check 1: Large + Small ---
Expression: 16777216.0 + 1.0
Actual result: 16777216.0
Float-equivalent expected: 16777216.0
Double-equivalent expected: 16777217.0
Match float: YES
Match double: NO
--- Precision Check 2: Cancellation ---
Expression: (16777216.0 + 1.0) - 16777216.0
Actual result: 0.0
Float-equivalent expected: 0.0
Double-equivalent expected: 1.0
Match float: YES
Match double: NO
--- Precision Check 3: 0.1 + 0.2 ---
Actual result: 0.30000001192092896
Float-equivalent expected: 0.30000001192092896
Double-equivalent expected: 0.30000000000000004
Match float: YES
Match double: NO
--- Precision Summary ---
Float-behavior matches: 3/3
Double-behavior matches: 0/3
Detected precision: float
--- Performance Benchmarks ---
Float Addition:
Iterations: 1000000
Elapsed ticks: 25365
Ops per tick: 39.42
Float Multiplication:
Iterations: 1000000
Elapsed ticks: 25399
Ops per tick: 39.37
Float Division:
Iterations: 1000000
Elapsed ticks: 25723
Ops per tick: 38.88
Mixed Operations:
Iterations: 1000000
Elapsed ticks: 28688
Ops per tick: 34.86
=== Benchmark Complete ===
```

</details>

<details>
<summary>Before this PR: MRBC_USE_FLOAT=2</summary>

```console
=== Float/Double Benchmark ===
mruby/c 3.4 (mruby:3.4.0 ruby:3.4)
--- Precision Check 1: Large + Small ---
Expression: 16777216.0 + 1.0
Actual result: 16777217.0
Float-equivalent expected: 16777216.0
Double-equivalent expected: 16777217.0
Match float: NO
Match double: YES
--- Precision Check 2: Cancellation ---
Expression: (16777216.0 + 1.0) - 16777216.0
Actual result: 1.0
Float-equivalent expected: 0.0
Double-equivalent expected: 1.0
Match float: NO
Match double: YES
--- Precision Check 3: 0.1 + 0.2 ---
Actual result: 0.30000000000000004
Float-equivalent expected: 0.30000001192092896
Double-equivalent expected: 0.30000000000000004
Match float: NO
Match double: YES
--- Precision Summary ---
Float-behavior matches: 0/3
Double-behavior matches: 3/3
Detected precision: double
--- Performance Benchmarks ---
Float Addition:
Iterations: 1000000
Elapsed ticks: 24655
Ops per tick: 40.56
Float Multiplication:
Iterations: 1000000
Elapsed ticks: 23688
Ops per tick: 42.22
Float Division:
Iterations: 1000000
Elapsed ticks: 28747
Ops per tick: 34.79
Mixed Operations:
Iterations: 1000000
Elapsed ticks: 29098
Ops per tick: 34.37
=== Benchmark Complete ===
```

</details>

<details>
<summary>After this PR: MRBC_USE_FLOAT=1</summary>

```console
=== Float/Double Benchmark ===
mruby/c 3.4 (mruby:3.4.0 ruby:3.4)
--- Precision Check 1: Large + Small ---
Expression: 16777216.0 + 1.0
Actual result: 16777216.0
Float-equivalent expected: 16777216.0
Double-equivalent expected: 16777217.0
Match float: YES
Match double: NO
--- Precision Check 2: Cancellation ---
Expression: (16777216.0 + 1.0) - 16777216.0
Actual result: 0.0
Float-equivalent expected: 0.0
Double-equivalent expected: 1.0
Match float: YES
Match double: NO
--- Precision Check 3: 0.1 + 0.2 ---
Actual result: 0.30000001192092896
Float-equivalent expected: 0.30000001192092896
Double-equivalent expected: 0.30000000000000004
Match float: YES
Match double: NO
--- Precision Summary ---
Float-behavior matches: 3/3
Double-behavior matches: 0/3
Detected precision: float
--- Performance Benchmarks ---
Float Addition:
Iterations: 1000000
Elapsed ticks: 24111
Ops per tick: 41.47
Float Multiplication:
Iterations: 1000000
Elapsed ticks: 24142
Ops per tick: 41.42
Float Division:
Iterations: 1000000
Elapsed ticks: 24202
Ops per tick: 41.32
Mixed Operations:
Iterations: 1000000
Elapsed ticks: 27184
Ops per tick: 36.79
=== Benchmark Complete ===
```

</details>

<details>
<summary>After this PR: MRBC_USE_FLOAT=2</summary>

```console
=== Float/Double Benchmark ===
mruby/c 3.4 (mruby:3.4.0 ruby:3.4)
--- Precision Check 1: Large + Small ---
Expression: 16777216.0 + 1.0
Actual result: 16777217.0
Float-equivalent expected: 16777216.0
Double-equivalent expected: 16777217.0
Match float: NO
Match double: YES
--- Precision Check 2: Cancellation ---
Expression: (16777216.0 + 1.0) - 16777216.0
Actual result: 1.0
Float-equivalent expected: 0.0
Double-equivalent expected: 1.0
Match float: NO
Match double: YES
--- Precision Check 3: 0.1 + 0.2 ---
Actual result: 0.30000000000000004
Float-equivalent expected: 0.30000001192092896
Double-equivalent expected: 0.30000000000000004
Match float: NO
Match double: YES
--- Precision Summary ---
Float-behavior matches: 0/3
Double-behavior matches: 3/3
Detected precision: double
--- Performance Benchmarks ---
Float Addition:
Iterations: 1000000
Elapsed ticks: 25473
Ops per tick: 39.26
Float Multiplication:
Iterations: 1000000
Elapsed ticks: 24339
Ops per tick: 41.09
Float Division:
Iterations: 1000000
Elapsed ticks: 29397
Ops per tick: 34.02
Mixed Operations:
Iterations: 1000000
Elapsed ticks: 29771
Ops per tick: 33.59
=== Benchmark Complete ===
```

</details>