### PR TITLE
Add Zephyr HAL implementation

### DIFF
--- a/hal/zephyr/hal.c
+++ b/hal/zephyr/hal.c
@@ -1,0 +1,161 @@
+/*! @file
+  @brief
+  Hardware abstraction layer
+        for Zephyr
+        Board examples: Nordic nRF52/nRF54/nRF91, ST Nucleo/Discovery,
+        Espressif ESP32 DevKit, NXP FRDM/i.MX RT EVK, Raspberry Pi Pico,
+        SiFive HiFive, Microchip SAM/PIC32, Renesas RA/RZ, Silicon Labs EFR32,
+        TI LaunchPad, and QEMU boards.
+
+  <pre>
+  Copyright (C) 2015-      Kyushu Institute of Technology.
+  Copyright (C) 2015-2026  Shimane IT Open-Innovation Center.
+  Copyright (C) 2026-      Shimane Institute for Industrial Technology.
+
+  This file is distributed under BSD 3-Clause License.
+  </pre>
+*/
+
+/***** Feature test switches ************************************************/
+/***** System headers *******************************************************/
+#include <stdint.h>
+#include <string.h>
+#include <zephyr/fatal.h>
+#include <zephyr/irq.h>
+#include <zephyr/sys/printk.h>
+
+/***** Local headers ********************************************************/
+#include "hal.h"
+
+/***** Constat values *******************************************************/
+/***** Macros ***************************************************************/
+/***** Typedefs *************************************************************/
+/***** Function prototypes **************************************************/
+/***** Local variables ******************************************************/
+static unsigned int hal_irq_lock_key;
+static uint32_t hal_irq_lock_count;
+static uint8_t hal_sched_locked;
+
+/***** Global variables *****************************************************/
+/***** Signal catching functions ********************************************/
+/***** Local functions ******************************************************/
+#ifndef MRBC_NO_TIMER
+//================================================================
+/*!@brief
+  Timer handler
+
+*/
+static void mrubyc_haltimerhandler(struct k_timer *timer)
+{
+  (void)timer;
+  mrbc_tick();
+}
+
+K_TIMER_DEFINE(mrubyc_haltimer, mrubyc_haltimerhandler, NULL);
+
+/***** Global functions *****************************************************/
+//================================================================
+/*!@brief
+  initialize
+
+*/
+void mrbc_hal_init(void)
+{
+  k_timer_start(&mrubyc_haltimer, K_MSEC(MRBC_TICK_UNIT), K_MSEC(MRBC_TICK_UNIT));
+}
+#else
+/***** Global functions *****************************************************/
+#endif
+
+//================================================================
+/*!@brief
+  enable interrupt
+
+*/
+void mrbc_hal_enable_irq(void)
+{
+  if( hal_irq_lock_count == 0 ) return;
+
+  hal_irq_lock_count--;
+  if( hal_irq_lock_count == 0 ) {
+    unsigned int key = hal_irq_lock_key;
+    uint8_t sched_locked = hal_sched_locked;
+
+    hal_irq_lock_key = 0;
+    hal_sched_locked = 0;
+    irq_unlock(key);
+    if( sched_locked ) k_sched_unlock();
+  }
+}
+
+//================================================================
+/*!@brief
+  disable interrupt
+
+*/
+void mrbc_hal_disable_irq(void)
+{
+  if( hal_irq_lock_count == 0 ) {
+    if( !k_is_in_isr() ) {
+      k_sched_lock();
+      hal_sched_locked = 1;
+    } else {
+      hal_sched_locked = 0;
+    }
+    hal_irq_lock_key = irq_lock();
+  }
+
+  hal_irq_lock_count++;
+}
+
+//================================================================
+/*!@brief
+  Write
+
+  @param  fd    dummy.
+  @param  buf   pointer of buffer.
+  @param  nbytes        output byte length.
+*/
+int mrbc_hal_write(int fd, const void *buf, int nbytes)
+{
+  (void)fd;
+
+  if( nbytes < 0 ) return -1;
+  if( nbytes == 0 ) return 0;
+  if( buf == NULL ) return -1;
+
+  const char *p = (const char *)buf;
+  for( int i = 0; i < nbytes; i++ ) {
+    printk("%c", (int)(unsigned char)p[i]);
+  }
+
+  return nbytes;
+}
+
+//================================================================
+/*!@brief
+  Flush write buffer
+
+  @param  fd    dummy.
+*/
+int mrbc_hal_flush(int fd)
+{
+  (void)fd;
+  return 0;
+}
+
+//================================================================
+/*!@brief
+  abort program
+
+  @param s      additional message.
+*/
+void mrbc_hal_abort(const char *s)
+{
+  if( s ) {
+    mrbc_hal_write(2, s, strlen(s));
+  }
+
+  k_panic();
+  k_fatal_halt(K_ERR_KERNEL_PANIC);
+}

--- a/hal/zephyr/hal.h
+++ b/hal/zephyr/hal.h
@@ -1,0 +1,95 @@
+/*! @file
+  @brief
+  Hardware abstraction layer
+        for Zephyr
+        Board examples: Nordic nRF52/nRF54/nRF91, ST Nucleo/Discovery,
+        Espressif ESP32 DevKit, NXP FRDM/i.MX RT EVK, Raspberry Pi Pico,
+        SiFive HiFive, Microchip SAM/PIC32, Renesas RA/RZ, Silicon Labs EFR32,
+        TI LaunchPad, and QEMU boards.
+
+  <pre>
+  Copyright (C) 2015-      Kyushu Institute of Technology.
+  Copyright (C) 2015-2026  Shimane IT Open-Innovation Center.
+  Copyright (C) 2026-      Shimane Institute for Industrial Technology.
+
+  This file is distributed under BSD 3-Clause License.
+  </pre>
+*/
+
+#ifndef MRBC_SRC_HAL_H_
+#define MRBC_SRC_HAL_H_
+
+/***** Feature test switches ************************************************/
+/***** System headers *******************************************************/
+#include <zephyr/kernel.h>
+
+/***** Local headers ********************************************************/
+#include "vm_config.h"
+
+/***** Constant values ******************************************************/
+/***** Macros ***************************************************************/
+#ifndef MRBC_SCHEDULER_EXIT
+#define MRBC_SCHEDULER_EXIT 1
+#endif
+
+#ifndef MRBC_TICK_UNIT_1_MS
+#define MRBC_TICK_UNIT_1_MS   1
+#endif
+#ifndef MRBC_TICK_UNIT_2_MS
+#define MRBC_TICK_UNIT_2_MS   2
+#endif
+#ifndef MRBC_TICK_UNIT_4_MS
+#define MRBC_TICK_UNIT_4_MS   4
+#endif
+#ifndef MRBC_TICK_UNIT_10_MS
+#define MRBC_TICK_UNIT_10_MS 10
+#endif
+
+#ifndef MRBC_TICK_UNIT
+#define MRBC_TICK_UNIT MRBC_TICK_UNIT_1_MS
+#endif
+
+#ifndef MRBC_TIMESLICE_TICK_COUNT
+#define MRBC_TIMESLICE_TICK_COUNT 10
+#endif
+
+/***** Typedefs *************************************************************/
+/***** Global variables *****************************************************/
+/***** Function prototypes **************************************************/
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void mrbc_tick(void);
+
+#ifndef MRBC_NO_TIMER
+void mrbc_hal_init(void);
+#define mrbc_hal_idle_cpu() k_msleep(MRBC_TICK_UNIT)
+#else
+#define mrbc_hal_init()        ((void)0)
+#define mrbc_hal_idle_cpu()    (k_msleep(MRBC_TICK_UNIT), mrbc_tick())
+#endif
+
+void mrbc_hal_enable_irq(void);
+void mrbc_hal_disable_irq(void);
+int mrbc_hal_write(int fd, const void *buf, int nbytes);
+int mrbc_hal_flush(int fd);
+void mrbc_hal_abort(const char *s);
+
+/***** Inline functions *****************************************************/
+
+/*
+  for legacy compatibility.
+*/
+#define hal_init()               mrbc_hal_init()
+#define hal_enable_irq()         mrbc_hal_enable_irq()
+#define hal_disable_irq()        mrbc_hal_disable_irq()
+#define hal_idle_cpu()           mrbc_hal_idle_cpu()
+#define hal_write(fd,buf,nbytes) mrbc_hal_write(fd,buf,nbytes)
+#define hal_flush(fd)            mrbc_hal_flush(fd)
+#define hal_abort(s)             mrbc_hal_abort(s)
+
+#ifdef __cplusplus
+}
+#endif
+#endif // ifndef MRBC_HAL_H_

--- a/src/hal_selector.mk
+++ b/src/hal_selector.mk
@@ -27,6 +27,9 @@ endif
 ifdef MRBC_USE_HAL_RP2040
   MRBC_USE_HAL = ../hal/rp2040
 endif
+ifdef MRBC_USE_HAL_ZEPHYR
+  MRBC_USE_HAL = ../hal/zephyr
+endif
 
 ifdef MRBC_USE_HAL
   HAL_DIR = $(MRBC_USE_HAL)


### PR DESCRIPTION
## Summary

This pull request adds a Zephyr-based HAL implementation for mruby/c.

The implementation uses Zephyr APIs rather than board-specific registers or vendor-specific HAL APIs, so it is intended to support Zephyr-compatible boards in a generic way.

By adding Zephyr support, mruby/c can be used on a wide range of Zephyr-supported targets. Examples include Nordic nRF52/nRF54/nRF91, ST Nucleo/Discovery, Espressif ESP32 DevKit, NXP FRDM/i.MX RT EVK, Raspberry Pi Pico, SiFive HiFive, Microchip SAM/PIC32, Renesas RA/RZ, Silicon Labs EFR32, TI LaunchPad, and QEMU boards.

## Changes

- Add `hal/zephyr/hal.c` and `hal/zephyr/hal.h`
- Add `MRBC_USE_HAL_ZEPHYR` support to `src/hal_selector.mk`
- Implement timer integration using Zephyr `k_timer`
- Implement interrupt and scheduler locking using Zephyr IRQ and scheduler APIs
- Implement output through Zephyr `printk()`
- Implement abort handling using Zephyr panic/fatal halt APIs
- Provide legacy HAL macro compatibility in the Zephyr HAL header

## Usage

The Zephyr HAL can be selected by defining `MRBC_USE_HAL_ZEPHYR` when building mruby/c.

## Notes

Although the initial hardware verification was performed on an nRF54L15-DK, this HAL is not intended to be nRF54-specific. It depends only on Zephyr APIs and should be applicable to other Zephyr-supported boards as well.

## Testing

I tested this change on real hardware using an nRF54L15-DK.

The test log and the source code used for the hardware test are available here:

- Test source code: https://github.com/uist1idrju3i/temporary/tree/mrubyc/zephyr-hal
- Test log (MRBC_NO_TIMER=1)
```console
*** Booting nRF Connect SDK v3.3.0-ba167d9f3db4 ***
*** Using Zephyr OS v4.3.99-fd9204a02d52 ***
mruby/c Zephyr HAL test start
42
3.5
hello zephyr
positive
0
1
2
tick ok
mruby/c Zephyr HAL test done
```
- Test log (Use timer)
```console
*** Booting nRF Connect SDK v3.3.0-ba167d9f3db4 ***
*** Using Zephyr OS v4.3.99-fd9204a02d52 ***
mruby/c Zephyr HAL test start
42
3.5
hello zephyr
positive
0
1
2
tick ok
mruby/c Zephyr HAL test done
```