### PR TITLE
Add Emscripten HAL for WebAssembly builds

### DIFF
--- a/hal/emscripten/hal.c
+++ b/hal/emscripten/hal.c
@@ -1,0 +1,293 @@
+/*! @file
+  @brief
+  Hardware abstraction layer
+        for Emscripten/WebAssembly
+
+  @note Link applications with -sASYNCIFY because this HAL uses
+        emscripten_sleep() to yield while mrbc_run() is idle.
+
+  <pre>
+  Copyright (C) 2015-      Kyushu Institute of Technology.
+  Copyright (C) 2015-2026  Shimane IT Open-Innovation Center.
+  Copyright (C) 2026-      Shimane Institute for Industrial Technology.
+
+  This file is distributed under BSD 3-Clause License.
+  </pre>
+*/
+
+/***** Feature test switches ************************************************/
+/***** System headers *******************************************************/
+#include <stdlib.h>
+#include <string.h>
+#include <emscripten.h>
+
+/***** Local headers ********************************************************/
+#include "hal.h"
+
+/***** Constat values *******************************************************/
+/***** Macros ***************************************************************/
+/***** Typedefs *************************************************************/
+/***** Function prototypes **************************************************/
+/***** Local variables ******************************************************/
+/***** Global variables *****************************************************/
+/***** JavaScript bridge functions ******************************************/
+EM_JS(void, mrbc_hal_js_output, (int fd, const char *buf, int nbytes, int flush), {
+  const root = typeof globalThis !== "undefined" ? globalThis :
+    (typeof self !== "undefined" ? self :
+    (typeof window !== "undefined" ? window :
+    (typeof global !== "undefined" ? global : {})));
+  const mod = typeof Module !== "undefined" ? Module : null;
+
+  /**
+   * Get the value of an own data property without invoking accessors.
+   *
+   * @param {object} object Object to inspect.
+   * @param {string} name Property name to read.
+   * @returns {*} Property value, or undefined when the property is missing or not a data property.
+   */
+  function getOwnDataProperty(object, name) {
+    if (!object || typeof Object.getOwnPropertyDescriptor !== "function") return undefined;
+
+    const descriptor = Object.getOwnPropertyDescriptor(object, name);
+    if (!descriptor || !Object.prototype.hasOwnProperty.call(descriptor, "value")) return undefined;
+
+    return descriptor.value;
+  }
+
+  const isErr = fd === 2;
+  const owner = mod || root;
+  const maxBufferedBytes = 4096;
+  let state = owner.__mrubycHalOutputState;
+  if (!state) {
+    state = {
+      out: [],
+      err: [],
+      outFlush: 0,
+      errFlush: 0,
+      decoder: typeof TextDecoder !== "undefined" ? new TextDecoder("utf-8") : null
+    };
+    owner.__mrubycHalOutputState = state;
+  }
+
+  const output = isErr ? state.err : state.out;
+  const flushKey = isErr ? "errFlush" : "outFlush";
+  const callbackName = isErr ? "mrubycError" : "mrubycOutput";
+  const printName = isErr ? "printErr" : "print";
+  const callback = getOwnDataProperty(mod, callbackName);
+  const print = getOwnDataProperty(mod, printName);
+  const stream = isErr ? (root.process && root.process.stderr)
+                       : (root.process && root.process.stdout);
+  const runtimeOutput = isErr ? (typeof err === "function" ? err : undefined)
+                              : (typeof out === "function" ? out : undefined);
+  const consoleObject = typeof console !== "undefined" ? console : null;
+  const consoleOutput = consoleObject ? (isErr ? consoleObject.error : consoleObject.log) : null;
+  const sinks = [
+    { target: undefined, write: callback },
+    { target: undefined, write: print },
+    { target: stream, write: stream && stream.write },
+    { target: undefined, write: runtimeOutput },
+    { target: consoleObject, write: consoleOutput }
+  ];
+
+  /**
+   * Decode buffered UTF-8 bytes into a JavaScript string.
+   *
+   * @param {number[]} bytes Buffered byte values.
+   * @returns {string} Decoded text.
+   */
+  function decode(bytes) {
+    if (state.decoder) {
+      return state.decoder.decode(new Uint8Array(bytes));
+    }
+
+    let text = "";
+    for (let i = 0; i < bytes.length; i++) {
+      text += String.fromCharCode(bytes[i]);
+    }
+    return text;
+  }
+
+  /**
+   * Emit text to the best available output sink.
+   *
+   * @param {string} text Decoded text to emit.
+   * @returns {void}
+   */
+  function emitText(text) {
+    for (let i = 0; i < sinks.length; i++) {
+      if (typeof sinks[i].write !== "function") continue;
+      sinks[i].write.call(sinks[i].target, text);
+      return;
+    }
+  }
+
+  /**
+   * Decode and emit buffered bytes.
+   *
+   * @param {number[]} bytes Buffered byte values to emit.
+   * @returns {void}
+   */
+  function emit(bytes) {
+    if (bytes.length === 0) return;
+    emitText(decode(bytes));
+  }
+
+  /**
+   * Emit and clear the buffered bytes for the selected stream.
+   *
+   * @returns {void}
+   */
+  function flushOutput() {
+    if (output.length !== 0) {
+      emit(output);
+      output.length = 0;
+    }
+  }
+
+  /**
+   * Flush buffered output after the current JavaScript turn.
+   *
+   * @returns {void}
+   */
+  function flushLater() {
+    state[flushKey] = 0;
+    flushOutput();
+  }
+
+  /**
+   * Schedule a callback after the current JavaScript turn.
+   *
+   * @param {Function} callback Callback to run later.
+   * @returns {void}
+   */
+  function scheduleLater(callback) {
+    const queue = typeof queueMicrotask !== "undefined" ? queueMicrotask : root["queueMicrotask"];
+    if (typeof queue === "function") {
+      queue(callback);
+      return;
+    }
+
+    const promise = typeof Promise !== "undefined" ? Promise : root["Promise"];
+    if (promise && typeof promise.resolve === "function") {
+      promise.resolve().then(callback);
+      return;
+    }
+
+    const schedule = typeof setTimeout !== "undefined" ? setTimeout : root["setTimeout"];
+    if (typeof schedule === "function") schedule(callback, 0);
+  }
+
+  /**
+   * Schedule a deferred flush for unterminated output.
+   *
+   * @returns {void}
+   */
+  function scheduleFlush() {
+    if (output.length === 0 || state[flushKey]) return;
+
+    state[flushKey] = 1;
+    scheduleLater(flushLater);
+  }
+
+  /**
+   * Append bytes to the selected stream buffer and flush complete lines or full chunks.
+   *
+   * @param {Uint8Array} bytes Bytes read from the WebAssembly heap.
+   * @returns {void}
+   */
+  function appendBytes(bytes) {
+    for (let i = 0; i < bytes.length; i++) {
+      output.push(bytes[i]);
+      if (bytes[i] === 10 || output.length >= maxBufferedBytes) {
+        flushOutput();
+      }
+    }
+  }
+
+  if (nbytes > 0) {
+    appendBytes(HEAPU8.subarray(buf, buf + nbytes));
+    scheduleFlush();
+  }
+
+  if (flush) flushOutput();
+});
+
+/***** Signal catching functions ********************************************/
+/***** Local functions ******************************************************/
+/***** Global functions *****************************************************/
+
+//================================================================
+/*!@brief
+  delay milliseconds
+
+  @param ms  delay milliseconds.
+*/
+void mrbc_hal_delay_ms(int ms)
+{
+  if( ms < 0 ) ms = 0;
+  emscripten_sleep((unsigned int)ms);
+}
+
+
+//================================================================
+/*!@brief
+  Write
+
+  @param  fd      1 = stdout, 2 = stderr.
+  @param  buf     pointer of buffer.
+  @param  nbytes  output byte length.
+*/
+int mrbc_hal_write(int fd, const void *buf, int nbytes)
+{
+  if( nbytes < 0 ) return -1;
+  if( nbytes == 0 ) return 0;
+  if( buf == NULL ) return -1;
+
+  mrbc_hal_js_output(fd, (const char *)buf, nbytes, 0);
+
+  return nbytes;
+}
+
+
+//================================================================
+/*!@brief
+  Flush write buffer
+
+  @param  fd      1 = stdout, 2 = stderr.
+*/
+int mrbc_hal_flush(int fd)
+{
+  mrbc_hal_js_output(fd, NULL, 0, 1);
+  return 0;
+}
+
+
+//================================================================
+/*!@brief
+  abort program
+
+  @param s  additional message.
+*/
+void mrbc_hal_abort(const char *s)
+{
+  if( s ) {
+    mrbc_hal_write(2, s, strlen(s));
+  }
+  mrbc_hal_flush(2);
+
+  emscripten_force_exit(EXIT_FAILURE);
+  abort();
+}
+
+
+//================================================================
+/*!@brief
+  out of memory
+
+*/
+void mrbc_out_of_memory_emscripten(void)
+{
+  static const char msg[] = "Fatal error: Out of memory.\n";
+  mrbc_hal_write(2, msg, sizeof(msg) - 1);
+  mrbc_hal_abort(0);
+}

--- a/hal/emscripten/hal.h
+++ b/hal/emscripten/hal.h
@@ -1,0 +1,95 @@
+/*! @file
+  @brief
+  Hardware abstraction layer
+        for Emscripten/WebAssembly
+
+  @note Link applications with -sASYNCIFY because this HAL uses
+        emscripten_sleep() to yield while mrbc_run() is idle.
+
+  <pre>
+  Copyright (C) 2015-      Kyushu Institute of Technology.
+  Copyright (C) 2015-2026  Shimane IT Open-Innovation Center.
+  Copyright (C) 2026-      Shimane Institute for Industrial Technology.
+
+  This file is distributed under BSD 3-Clause License.
+  </pre>
+*/
+
+#ifndef MRBC_SRC_HAL_H_
+#define MRBC_SRC_HAL_H_
+
+/***** Feature test switches ************************************************/
+/***** System headers *******************************************************/
+#include <emscripten.h>
+
+/***** Local headers ********************************************************/
+/***** Constant values ******************************************************/
+/***** Macros ***************************************************************/
+#ifndef MRBC_NO_TIMER
+#define MRBC_NO_TIMER
+#endif
+
+#ifndef MRBC_SCHEDULER_EXIT
+#define MRBC_SCHEDULER_EXIT 1
+#endif
+
+#ifndef MRBC_TICK_UNIT_1_MS
+#define MRBC_TICK_UNIT_1_MS   1
+#endif
+#ifndef MRBC_TICK_UNIT_2_MS
+#define MRBC_TICK_UNIT_2_MS   2
+#endif
+#ifndef MRBC_TICK_UNIT_4_MS
+#define MRBC_TICK_UNIT_4_MS   4
+#endif
+#ifndef MRBC_TICK_UNIT_10_MS
+#define MRBC_TICK_UNIT_10_MS 10
+#endif
+
+#ifndef MRBC_TICK_UNIT
+#define MRBC_TICK_UNIT MRBC_TICK_UNIT_10_MS
+#endif
+
+#ifndef MRBC_TIMESLICE_TICK_COUNT
+#define MRBC_TIMESLICE_TICK_COUNT 10
+#endif
+
+#define MRBC_OUT_OF_MEMORY() mrbc_out_of_memory_emscripten()
+
+/***** Typedefs *************************************************************/
+/***** Global variables *****************************************************/
+/***** Function prototypes **************************************************/
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void mrbc_tick(void);
+
+#define mrbc_hal_init()        ((void)0)
+#define mrbc_hal_enable_irq()  ((void)0)
+#define mrbc_hal_disable_irq() ((void)0)
+void mrbc_hal_delay_ms(int ms);
+#define mrbc_hal_idle_cpu()    (mrbc_hal_delay_ms(MRBC_TICK_UNIT), mrbc_tick())
+
+int mrbc_hal_write(int fd, const void *buf, int nbytes);
+int mrbc_hal_flush(int fd);
+void mrbc_hal_abort(const char *s);
+void mrbc_out_of_memory_emscripten(void);
+
+/***** Inline functions *****************************************************/
+
+/*
+  for legacy compatibility.
+*/
+#define hal_init()               mrbc_hal_init()
+#define hal_enable_irq()         mrbc_hal_enable_irq()
+#define hal_disable_irq()        mrbc_hal_disable_irq()
+#define hal_idle_cpu()           mrbc_hal_idle_cpu()
+#define hal_write(fd,buf,nbytes) mrbc_hal_write(fd,buf,nbytes)
+#define hal_flush(fd)            mrbc_hal_flush(fd)
+#define hal_abort(s)             mrbc_hal_abort(s)
+
+#ifdef __cplusplus
+}
+#endif
+#endif // ifndef MRBC_HAL_H_

--- a/src/hal_selector.mk
+++ b/src/hal_selector.mk
@@ -30,6 +30,9 @@ endif
 ifdef MRBC_USE_HAL_ZEPHYR
   MRBC_USE_HAL = ../hal/zephyr
 endif
+ifdef MRBC_USE_HAL_EMSCRIPTEN
+  MRBC_USE_HAL = ../hal/emscripten
+endif
 
 ifdef MRBC_USE_HAL
   HAL_DIR = $(MRBC_USE_HAL)


### PR DESCRIPTION
## Summary

This PR adds a new Emscripten/WebAssembly HAL and a `MRBC_USE_HAL_EMSCRIPTEN` selector so mruby/c applications can be built with Emscripten and run as WebAssembly.

The implementation is kept localized to the HAL layer and the HAL selector.

## Motivation

I understand that mruby/c is primarily designed for one-chip microprocessors and small embedded systems, while browsers and Node.js are not its usual deployment targets.

The goal of this HAL is not to turn mruby/c into a general-purpose browser or Node.js runtime. Instead, it provides a development and tooling target that can run the same mruby/c VM implementation outside the actual embedded hardware.

This can be useful for browser-based demos, VS Code Webviews, and Node.js-based tooling, including VS Code extensions when built with an appropriate Emscripten runtime environment. For example, developers can compile Ruby code into `.mrb` bytecode and run it with the mruby/c VM before flashing it to hardware. This may help catch language-level or VM-level problems such as `NoMethodError` earlier in the development flow.

Hardware-specific behavior, timing, and peripherals still need to be tested on the actual target devices.

## Changes

- Add `hal/emscripten/hal.c` and `hal/emscripten/hal.h`.
- Add `MRBC_USE_HAL_EMSCRIPTEN` to `src/hal_selector.mk`.
- Use mruby/c's existing cooperative scheduler path with `MRBC_NO_TIMER`.
- Implement idle/delay behavior with `emscripten_sleep()`.
  - The HAL documents `-sASYNCIFY` as the expected link option.
  - Emscripten documents this style of `emscripten_sleep()` usage as yielding to the browser/event loop when compiled with async support.
- Provide stdout/stderr forwarding for browser-like and Node.js-style runtimes.

## Sample

I also prepared a small sample repository here:

https://github.com/uist1idrju3i/temporary/tree/mrubyc/emscripten-hal

The sample demonstrates a browser-oriented flow where:

1. `mrbc.js` compiles Ruby source code into `.mrb` bytecode.
2. `mrubyc.js` runs the generated bytecode with the mruby/c VM.
3. JavaScript connects the compiler, VM, and browser UI.

The same high-level approach can be adapted for Node.js-based tools, including VS Code extensions, by rebuilding with an Emscripten runtime environment that supports Node.js and by resolving the generated `.wasm` files from the extension or package installation directory.

## Reference

Emscripten Asyncify documentation:

https://emscripten.org/docs/porting/asyncify.html