### PR TITLE
Fix tests for Pattern Matching

### DIFF
--- a/test/pattern_match_test.rb
+++ b/test/pattern_match_test.rb
@@ -90,7 +90,7 @@ class PatternMatchTest < Picotest::Test
     assert_equal :other, result
   end
 
-  description "no match returns nil"
+  description "no match raises"
   def test_no_match_raises
     assert_raise(NoMatchingPatternError) do
       case 99

--- a/test/pattern_match_test.rb
+++ b/test/pattern_match_test.rb
@@ -91,14 +91,15 @@ class PatternMatchTest < Picotest::Test
   end
 
   description "no match returns nil"
-  def test_no_match_returns_nil
-    result = case 99
-    in 1
-      :one
-    in 2
-      :two
+  def test_no_match_raises
+    assert_raise(NoMatchingPatternError) do
+      case 99
+      in 1
+        :one
+      in 2
+        :two
+      end
     end
-    assert_equal nil, result
   end
 
   description "alternative pattern"
@@ -496,11 +497,12 @@ class PatternMatchTest < Picotest::Test
 
   description "find pattern no match"
   def test_find_pattern_no_match
-    result = case [1, 2, 3]
-    in [*, 5, 6, *]
-      :match
+    assert_raise(NoMatchingPatternError) do
+      case [1, 2, 3]
+      in [*, 5, 6, *]
+        :match
+      end
     end
-    assert_equal nil, result
   end
 
   description "find pattern at beginning"


### PR DESCRIPTION
- Due to mruby-compiler2's bug, some tests mistakingly have asserted no_match case
- Fix them to raise NoMatchingPatternError instead of returning nil
- mruby-compiler2 upstread already fixed, so this should work in the next CI