### PR TITLE
Fix autogen.yml

### DIFF
--- a/.github/workflows/autogen.yml
+++ b/.github/workflows/autogen.yml
@@ -15,9 +15,9 @@ jobs:
     steps:
     - uses: actions/checkout@v6
 
-    - name: Generate autogen files
+    - name: Generate release autogen files
       run: |
-        make autogen
+        make -C src autogen
         sed -E -e '/^[A-Z]+_VERSION/!d' mrblib/global.rb > src/VERSION
 
     - name: Create release archive with autogen files


### PR DESCRIPTION
- When release, `autogen` target in top-level Makefile also tries to compile mrblib with mrbc
- But GitHub Actions doesn't have mrbc and fails the release work
- The fix is to execute only `autogen` task in src/Makefile and avoid executing mrbc compilation