### PR TITLE
Fix MRBC_USE_FLOAT=0 build

### DIFF
--- a/src/boxing_no.h
+++ b/src/boxing_no.h
@@ -56,13 +56,17 @@ typedef struct RObject {
 */
 #define mrbc_type(o)		((o).tt)
 #define mrbc_integer(o)		((o).i)
+#if MRBC_USE_FLOAT
 #define mrbc_float(o)		((o).d)
+#endif
 #define mrbc_symbol(o)		((o).sym_id)
 
 
 // make immediate values.
 #define mrbc_integer_value(n)	((mrbc_value){.tt = MRBC_TT_INTEGER, .i=(n)})
+#if MRBC_USE_FLOAT
 #define mrbc_float_value(vm,n)	((mrbc_value){.tt = MRBC_TT_FLOAT, .d=(n)})
+#endif
 #define mrbc_nil_value()	((mrbc_value){.tt = MRBC_TT_NIL})
 #define mrbc_true_value()	((mrbc_value){.tt = MRBC_TT_TRUE})
 #define mrbc_false_value()	((mrbc_value){.tt = MRBC_TT_FALSE})
@@ -84,11 +88,13 @@ static inline void mrbc_set_integer(mrbc_value *p, mrbc_int_t n)
   p->i = n;
 }
 
+#if MRBC_USE_FLOAT
 static inline void mrbc_set_float(mrbc_value *p, mrbc_float_t d)
 {
   p->tt = MRBC_TT_FLOAT;
   p->d = d;
 }
+#endif
 
 static inline void mrbc_set_nil(mrbc_value *p)
 {

--- a/src/class.c
+++ b/src/class.c
@@ -41,7 +41,11 @@ mrbc_class * const mrbc_class_tbl[MRBC_TT_MAXVAL+1] = {
   MRBC_CLASS(FalseClass),       // MRBC_TT_FALSE     = 2,
   MRBC_CLASS(TrueClass),        // MRBC_TT_TRUE      = 3,
   MRBC_CLASS(Integer),          // MRBC_TT_INTEGER   = 4,
+#if MRBC_USE_FLOAT
   MRBC_CLASS(Float),            // MRBC_TT_FLOAT     = 5,
+#else
+  0,                            // MRBC_TT_FLOAT     = 5,
+#endif
   MRBC_CLASS(Symbol),           // MRBC_TT_SYMBOL    = 6,
   0,                            // MRBC_TT_CLASS     = 7,
   0,                            // MRBC_TT_MODULE    = 8,

--- a/src/console.h
+++ b/src/console.h
@@ -93,7 +93,9 @@ int mrbc_printf_char(mrbc_printf_t *pf, int ch);
 int mrbc_printf_bstr(mrbc_printf_t *pf, const char *str, int len, int pad);
 int mrbc_printf_int(mrbc_printf_t *pf, mrbc_int_t value, unsigned int base);
 int mrbc_printf_bit(mrbc_printf_t *pf, mrbc_int_t value, int bit);
+#if MRBC_USE_FLOAT
 int mrbc_printf_float(mrbc_printf_t *pf, double value);
+#endif
 int mrbc_printf_pointer(mrbc_printf_t *pf, void *ptr);
 //@endcond
 

--- a/src/value.c
+++ b/src/value.c
@@ -288,8 +288,10 @@ mrbc_int_t mrbc_val_i(struct VM *vm, const mrbc_value *val)
   case MRBC_TT_INTEGER:
     return val->i;
 
+#if MRBC_USE_FLOAT
   case MRBC_TT_FLOAT:
     return val->d;
+#endif
 
   default:
     ;
@@ -337,8 +339,10 @@ double mrbc_val_f(struct VM *vm, const mrbc_value *val)
   case MRBC_TT_INTEGER:
     return val->i;
 
+#if MRBC_USE_FLOAT
   case MRBC_TT_FLOAT:
     return val->d;
+#endif
 
   default:
     ;
@@ -438,9 +442,11 @@ mrbc_int_t mrbc_to_i(struct VM *vm, mrbc_value v[], int argc, mrbc_value *val)
   case MRBC_TT_INTEGER:
     break;
 
+#if MRBC_USE_FLOAT
   case MRBC_TT_FLOAT:
     mrbc_set_integer(val, val->d);
     break;
+#endif
 
   default:{
     mrbc_value ret = mrbc_send( vm, v, argc, val, "to_i", 0 );
@@ -455,6 +461,7 @@ mrbc_int_t mrbc_to_i(struct VM *vm, mrbc_value v[], int argc, mrbc_value *val)
 }
 
 
+#if MRBC_USE_FLOAT
 //================================================================
 /*! (beta) Convert mrbc_value type to Float.
 
@@ -494,6 +501,7 @@ mrbc_float_t mrbc_to_f(struct VM *vm, mrbc_value v[], int argc, mrbc_value *val)
 
   return val->d;
 }
+#endif
 
 
 //================================================================
@@ -582,8 +590,10 @@ mrbc_int_t mrbc_arg_i(struct VM *vm, mrbc_value v[], int argc, int n)
   case MRBC_TT_INTEGER:
     return v[n].i;
 
+#if MRBC_USE_FLOAT
   case MRBC_TT_FLOAT:
     return v[n].d;
+#endif
 
   default:
     ;
@@ -639,8 +649,10 @@ mrbc_float_t mrbc_arg_f(struct VM *vm, mrbc_value v[], int argc, int n)
   case MRBC_TT_INTEGER:
     return v[n].i;
 
+#if MRBC_USE_FLOAT
   case MRBC_TT_FLOAT:
     return v[n].d;
+#endif
 
   default:
     ;

--- a/src/value.c
+++ b/src/value.c
@@ -253,6 +253,7 @@ int mrbc_strcpy( char *dest, int destsize, const char *src )
 }
 
 
+#if MRBC_USE_FLOAT
 //================================================================
 /*! format float value to string
 
@@ -268,6 +269,7 @@ void mrbc_format_float(char *buf, int bufsiz, mrbc_float_t flo)
   int len = strlen(buf);
   mrbc_strcpy( buf + len,  bufsiz - len, ".0" );
 }
+#endif
 
 
 //================================================================

--- a/src/value.h
+++ b/src/value.h
@@ -523,7 +523,9 @@ extern void (* const mrbc_delfunc[])(mrbc_value *);
 int mrbc_compare(const mrbc_value *v1, const mrbc_value *v2);
 mrbc_int_t mrbc_atoi(const char *s, int base);
 int mrbc_strcpy(char *dest, int destsize, const char *src);
+#if MRBC_USE_FLOAT
 void mrbc_format_float(char *buf, int bufsiz, mrbc_float_t flo);
+#endif
 mrbc_int_t mrbc_val_i(struct VM *vm, const mrbc_value *val);
 mrbc_int_t mrbc_val_i2(struct VM *vm, const mrbc_value *val, mrbc_int_t default_value);
 double mrbc_val_f(struct VM *vm, const mrbc_value *val);

--- a/src/value.h
+++ b/src/value.h
@@ -273,6 +273,7 @@ typedef struct RObject mrb_value;	// not recommended.
   @def MRBC_TO_FLOAT(val)
   Convert mrbc_value to C-lang double.
 */
+#if MRBC_USE_FLOAT
 #define MRBC_ISNUMERIC(val) \
   ((val).tt == MRBC_TT_INTEGER || (val).tt == MRBC_TT_FLOAT)
 #define MRBC_TO_INT(val) \
@@ -281,6 +282,14 @@ typedef struct RObject mrb_value;	// not recommended.
 #define MRBC_TO_FLOAT(val) \
   (val).tt == MRBC_TT_FLOAT ? (val).d : \
   (val).tt == MRBC_TT_INTEGER ? (mrbc_float_t)(val).i : (mrbc_float_t)0
+#else
+#define MRBC_ISNUMERIC(val) \
+  ((val).tt == MRBC_TT_INTEGER)
+#define MRBC_TO_INT(val) \
+  (val).tt == MRBC_TT_INTEGER ? (val).i : 0
+#define MRBC_TO_FLOAT(val) \
+  (val).tt == MRBC_TT_INTEGER ? (mrbc_float_t)(val).i : (mrbc_float_t)0
+#endif
 
 #endif  // !defined(MRBC_NOT_RECOMMEND_TO_USE)
 


### PR DESCRIPTION
## Summary

- Guard Float-only accessors in the non-boxing value representation.
- Guard Float-specific value conversion paths in `value.c`.
- Make numeric conversion helper macros avoid `.d` access when `MRBC_USE_FLOAT=0`.

## Motivation

`vm_config.h` documents `MRBC_USE_FLOAT=0` as the no-Float configuration, but building with that setting failed because `boxing_no.h` removes the `.d` member while some Float helper paths still referenced it.

## Verification

- `make BUILD_DIR="$tmpdir" CC=gcc CFLAGS="-Wall -g -I../hal/posix -DMRBC_USE_FLOAT=0"`
- `make BUILD_DIR="$tmpdir" CFLAGS="-Wall -g -I../hal/posix -DMRBC_USE_FLOAT=1"`
- `make BUILD_DIR="$tmpdir"`
- `git diff --check`
- Compiled a temporary external C file including `mrubyc.h` and using `MRBC_ISNUMERIC`, `MRBC_TO_INT`, `MRBC_TO_FLOAT`, `MRBC_VAL_I`, `MRBC_VAL_F`, `MRBC_ARG_I`, and `MRBC_ARG_F` with `MRBC_USE_FLOAT=0`.
