### PR TITLE
Support MRBC_USE_STRING=0 builds

### DIFF
--- a/src/c_object.c
+++ b/src/c_object.c
@@ -26,6 +26,7 @@
 #include "mrubyc.h"
 
 /***** Local functions ******************************************************/
+#if MRBC_USE_STRING
 //================================================================
 /*! set symbol name by symbol ID
  */
@@ -45,6 +46,7 @@ static int set_sym_name_by_id( char *buf, int bufsiz, mrbc_sym sym_id )
 
   return n;
 }
+#endif
 
 
 /***** global functions *****************************************************/
@@ -77,6 +79,7 @@ void mrbc_instance_call_initialize( mrbc_vm *vm, mrbc_value v[], int argc )
 }
 
 
+#if MRBC_USE_STRING
 //================================================================
 /*! Object#inspect, Object.inspect method main routine.
  */
@@ -101,6 +104,7 @@ void mrbc_object_inspect(mrbc_vm *vm, mrbc_value v[], int argc)
 
   SET_RETURN( mrbc_string_new_cstr( vm, buf ));
 }
+#endif
 
 
 /***** Object class *********************************************************/

--- a/src/c_object.h
+++ b/src/c_object.h
@@ -32,7 +32,9 @@ extern "C" {
 /***** Function prototypes **************************************************/
 //@cond
 void mrbc_instance_call_initialize(mrbc_vm *vm, mrbc_value v[], int argc);
+#if MRBC_USE_STRING
 void mrbc_object_inspect(mrbc_vm *vm, mrbc_value v[], int argc);
+#endif
 //@endcond
 
 

--- a/src/class.c
+++ b/src/class.c
@@ -48,7 +48,11 @@ mrbc_class * const mrbc_class_tbl[MRBC_TT_MAXVAL+1] = {
   0,                            // MRBC_TT_OBJECT    = 9,
   MRBC_CLASS(Proc),             // MRBC_TT_PROC      = 10,
   MRBC_CLASS(Array),            // MRBC_TT_ARRAY     = 11,
+#if MRBC_USE_STRING
   MRBC_CLASS(String),           // MRBC_TT_STRING    = 12,
+#else
+  0,                            // MRBC_TT_STRING    = 12,
+#endif
   MRBC_CLASS(Range),            // MRBC_TT_RANGE     = 13,
   MRBC_CLASS(Hash),             // MRBC_TT_HASH      = 14,
   0,                            // MRBC_TT_EXCEPTION = 15,

--- a/src/error.c
+++ b/src/error.c
@@ -260,16 +260,21 @@ static void c_exception_new(struct VM *vm, mrbc_value v[], int argc)
   assert( mrbc_type(v[0]) == MRBC_TT_CLASS );
 
   mrbc_value value;
+#if MRBC_USE_STRING
   if( argc == 1 && mrbc_type(v[1]) == MRBC_TT_STRING ) {
     value = mrbc_exception_new(vm, v[0].cls, mrbc_string_cstr(&v[1]), mrbc_string_size(&v[1]));
   } else {
+#endif
     value = mrbc_exception_new(vm, v[0].cls, NULL, 0);
+#if MRBC_USE_STRING
   }
+#endif
 
   SET_RETURN(value);
 }
 
 
+#if MRBC_USE_STRING
 //================================================================
 /*! (method) message
  */
@@ -286,6 +291,7 @@ static void c_exception_message(struct VM *vm, mrbc_value v[], int argc)
   mrbc_decref( &v[0] );
   v[0] = value;
 }
+#endif
 
 
 /* mruby/c Exception class hierarchy.
@@ -311,7 +317,9 @@ static void c_exception_message(struct VM *vm, mrbc_value v[], int argc)
 
   CLASS("Exception")
   METHOD("new", c_exception_new )
+#if MRBC_USE_STRING
   METHOD("message", c_exception_message )
+#endif
 
   CLASS("NoMemoryError")
   SUPER("Exception")

--- a/src/rrt0.c
+++ b/src/rrt0.c
@@ -928,9 +928,11 @@ static void c_task_get(mrbc_vm *vm, mrbc_value v[], int argc)
   }
 
   // in case of Task.get("TasName")
+#if MRBC_USE_STRING
   else if( mrbc_type(v[1]) == MRBC_TT_STRING ) {
     tcb = mrbc_find_task( mrbc_string_cstr( &v[1] ) );
   }
+#endif
 
   if( tcb ) {
     mrbc_value ret = mrbc_instance_new(vm, v->cls, sizeof(mrbc_tcb *));
@@ -969,6 +971,7 @@ static void c_task_list(mrbc_vm *vm, mrbc_value v[], int argc)
 }
 
 
+#if MRBC_USE_STRING
 //================================================================
 /*! (method) task name list
 
@@ -1038,6 +1041,7 @@ static void c_task_name(mrbc_vm *vm, mrbc_value v[], int argc)
 
   SET_RETURN(ret);
 }
+#endif
 
 
 //================================================================
@@ -1096,6 +1100,7 @@ static void c_task_priority(mrbc_vm *vm, mrbc_value v[], int argc)
 
   task.status() -> String
 */
+#if MRBC_USE_STRING
 static void c_task_status(mrbc_vm *vm, mrbc_value v[], int argc)
 {
   static const char *status_name[] =
@@ -1114,6 +1119,7 @@ static void c_task_status(mrbc_vm *vm, mrbc_value v[], int argc)
 
   SET_RETURN(ret);
 }
+#endif
 
 
 //================================================================
@@ -1260,6 +1266,7 @@ static void c_task_pass(mrbc_vm *vm, mrbc_value v[], int argc)
 
   Task.create( byte_code, regs_size = nil ) -> Task
 */
+#if MRBC_USE_STRING
 static void c_task_create(mrbc_vm *vm, mrbc_value v[], int argc)
 {
   const char *byte_code;
@@ -1296,6 +1303,7 @@ static void c_task_create(mrbc_vm *vm, mrbc_value v[], int argc)
  ERROR_ARGUMENT:
   mrbc_raise( vm, MRBC_CLASS(ArgumentError), 0 );
 }
+#endif
 
 
 //================================================================
@@ -1338,12 +1346,16 @@ static void c_task_rewind(mrbc_vm *vm, mrbc_value v[], int argc)
   METHOD( "get", c_task_get )
   METHOD( "current", c_task_get )
   METHOD( "list", c_task_list )
+#if MRBC_USE_STRING
   METHOD( "name_list", c_task_name_list )
   METHOD( "name=", c_task_set_name )
   METHOD( "name", c_task_name )
+#endif
   METHOD( "priority=", c_task_set_priority )
   METHOD( "priority", c_task_priority )
+#if MRBC_USE_STRING
   METHOD( "status", c_task_status )
+#endif
 
   METHOD( "suspend", c_task_suspend )
   METHOD( "resume", c_task_resume )
@@ -1354,7 +1366,9 @@ static void c_task_rewind(mrbc_vm *vm, mrbc_value v[], int argc)
   METHOD( "value", c_task_value )
   METHOD( "pass", c_task_pass )
 
+#if MRBC_USE_STRING
   METHOD( "create", c_task_create )
+#endif
   METHOD( "run", c_task_run )
   METHOD( "rewind", c_task_rewind )
 */


### PR DESCRIPTION
## Summary
- Guard String-dependent core paths behind `MRBC_USE_STRING`
- Avoid unresolved String symbols when building with `MRBC_USE_STRING=0`
- Keep String-returning Task, Exception, and Object inspect paths consistent with existing feature guards

## Verification
- `git diff --check`
- Clean POSIX build and `sample_c` link: default
- Clean POSIX build and `sample_c` link: `MRBC_USE_STRING=0`
- Clean POSIX build and `sample_c` link: `MRBC_USE_STRING=0 MRBC_USE_STRING_UTF8=1`
- Clean POSIX build and `sample_c` link: `MRBC_USE_STRING_UTF8=1 MRBC_USE_UNICODE_CASE=1`