### PR TITLE
Fix MRBC_INT16 varargs handling for %D

### DIFF
--- a/src/console.c
+++ b/src/console.c
@@ -62,7 +62,11 @@ static int mrbc_printf_sub_output_arg( mrbc_printf_t *pf, va_list *ap )
     break;
 
   case 'D':	// for mrbc_int_t (see mrbc_print_sub)
+#if defined(MRBC_INT16)
+    ret = mrbc_printf_int( pf, (mrbc_int_t)va_arg(*ap, int), 10);
+#else
     ret = mrbc_printf_int( pf, va_arg(*ap, mrbc_int_t), 10);
+#endif
     break;
 
   case 'b':


### PR DESCRIPTION
## Summary

This PR fixes the `%D` formatting path in `src/console.c` when `MRBC_INT16` is enabled.

With `MRBC_INT16`, `mrbc_int_t` is `int16_t`. When such a value is passed through a variadic function, C default argument promotions promote it to `int`. The `%D` path previously read the argument with `va_arg(*ap, mrbc_int_t)`, which does not match the promoted argument type and can trigger undefined behavior.

This change reads the `%D` argument as `int` only when `MRBC_INT16` is defined, then casts it back to `mrbc_int_t` before passing it to `mrbc_printf_int()`. The existing behavior is unchanged for the default 32-bit integer configuration and for `MRBC_INT64`.

## Background

I checked the C variadic argument rules while preparing this fix. The relevant rule is that the type used with `va_arg()` must match the actual argument type after default argument promotions. Smaller integer types such as `short`/`int16_t` are promoted before being passed as variadic arguments, so they need to be retrieved as `int` and then cast back if necessary.

## Testing

- `git diff --check`
- `cc -I../hal/posix -Wall -Wextra -DMRBC_INT16 -fsyntax-only console.c`
- `cc -I../hal/posix -Wall -Wextra -fsyntax-only console.c`
- `cc -I../hal/posix -Wall -Wextra -DMRBC_INT64 -fsyntax-only console.c`
- `cc -I../hal/posix -Wall -Wextra -DMRBC_INT16 -fsyntax-only *.c ../hal/posix/hal.c` checked for no `va_arg`/`varargs`/`error:` output
- `cc -I../hal/posix -Wall -Wextra -fsyntax-only *.c ../hal/posix/hal.c` checked for no `va_arg`/`varargs`/`error:` output
- `cc -I../hal/posix -Wall -Wextra -DMRBC_INT64 -fsyntax-only *.c ../hal/posix/hal.c` checked for no `va_arg`/`varargs`/`error:` output
- POSIX `src` builds with temporary `BUILD_DIR` for default, `MRBC_INT16`, and `MRBC_INT64`
