### PR TITLE
Fix MRBC_ALLOC_VMID build

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -54,6 +54,7 @@
 #if !defined(MRBC_ALLOC_LIBC)
 /***** Local headers ********************************************************/
 #include "alloc.h"
+#include "vm.h"
 #include "hal.h"
 #if defined(MRBC_DEBUG)
 #include "console.h"

--- a/src/value.h
+++ b/src/value.h
@@ -533,6 +533,9 @@ const char *mrbc_arg_s(struct VM *vm, mrbc_value v[], int argc, int n);
 const char *mrbc_arg_s2(struct VM *vm, mrbc_value v[], int argc, int n, const char *default_value);
 int mrbc_arg_b(struct VM *vm, mrbc_value v[], int argc, int n);
 int mrbc_arg_b2(struct VM *vm, mrbc_value v[], int argc, int n, int default_value);
+#if defined(MRBC_ALLOC_VMID)
+void mrbc_clear_vm_id(mrbc_value *v);
+#endif
 //@endcond
 
 


### PR DESCRIPTION
## Summary

This fixes build issues when `MRBC_ALLOC_VMID` is enabled.

`alloc.c` accesses `vm->vm_id` in the VMID allocator paths, but it only saw the forward declaration of `struct VM` from `alloc.h`. Including `vm.h` gives `alloc.c` the complete VM definition before those member accesses.

This also declares `mrbc_clear_vm_id()` from `value.h` when `MRBC_ALLOC_VMID` is enabled. Several VMID clear paths call this function through the public headers, and modern C compilers can otherwise report implicit-function-declaration diagnostics.

The intentionally invalid `MRBC_ALLOC_LIBC && MRBC_ALLOC_VMID` combination is still rejected by the existing `#error`; this PR only avoids unrelated follow-on diagnostic noise.

## Changes

- Include `vm.h` from `alloc.c` after `alloc.h`.
- Add the `MRBC_ALLOC_VMID`-guarded prototype for `mrbc_clear_vm_id()` to `value.h`.

## Validation

- `cc -I../hal/posix -fsyntax-only alloc.c`
- `cc -I../hal/posix -DMRBC_ALLOC_VMID -fsyntax-only alloc.c`
- `cc -I../hal/posix -DMRBC_ALLOC_VMID -DMRBC_ALLOC_16BIT -fsyntax-only alloc.c`
- `cc -I../hal/posix -DMRBC_ALLOC_VMID -Werror=implicit-function-declaration -fsyntax-only c_array.c`
- `cc -I../hal/posix -DMRBC_ALLOC_VMID -Werror=implicit-function-declaration -fsyntax-only keyvalue.c`
- `cc -I../hal/posix -DMRBC_ALLOC_VMID -Werror=implicit-function-declaration -fsyntax-only c_range.c`
- `cc -I../hal/posix -DMRBC_ALLOC_VMID -Werror=implicit-function-declaration -fsyntax-only value.c`
- Checked all `src/*.c` with `MRBC_ALLOC_LIBC && MRBC_ALLOC_VMID` and `-Werror=implicit-function-declaration`; no implicit-declaration noise remains, only the intentional allocator `#error`.
- POSIX `src` build with default allocator succeeded using a temporary `BUILD_DIR`.
- POSIX `src` build with `CC="cc -DMRBC_ALLOC_VMID"` succeeded using a temporary `BUILD_DIR`.
- `git diff --check`
