### PR TITLE
Fix 16-bit integer shift warnings

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -293,9 +293,9 @@ static inline int nlz8(uint8_t x)
 static inline unsigned int calc_index(MRBC_ALLOC_MEMSIZE_T alloc_size)
 {
   // check overflow
-  if( (alloc_size >> (MRBC_ALLOC_FLI_BIT_WIDTH
-                      + MRBC_ALLOC_SLI_BIT_WIDTH
-                      + MRBC_ALLOC_IGNORE_LSBS)) != 0) {
+  if( ((uint32_t)alloc_size >> (MRBC_ALLOC_FLI_BIT_WIDTH
+                                + MRBC_ALLOC_SLI_BIT_WIDTH
+                                + MRBC_ALLOC_IGNORE_LSBS)) != 0) {
     return SIZE_FREE_BLOCKS - 1;
   }
 

--- a/src/c_numeric.c
+++ b/src/c_numeric.c
@@ -53,8 +53,14 @@ static void c_integer_bitref(mrbc_vm *vm, mrbc_value v[], int argc)
       (argc != 1 && mrbc_integer(v[2]) <= 0) ) {
     SET_INT_RETURN( 0 );
   } else {
-    mrbc_uint_t mask = (argc == 1) ? 1 :
-      (mrbc_integer(v[2]) >= INT_BITS) ? (mrbc_uint_t)-1 : ((mrbc_uint_t)1 << mrbc_integer(v[2])) - 1;
+    mrbc_uint_t mask;
+    if( argc == 1 ) {
+      mask = 1;
+    } else if( mrbc_integer(v[2]) >= INT_BITS ) {
+      mask = (mrbc_uint_t)-1;
+    } else {
+      mask = ((mrbc_uint_t)1 << mrbc_integer(v[2])) - 1;
+    }
     mrbc_uint_t ret = (mrbc_uint_t)(mrbc_integer(v[0]) >> mrbc_integer(v[1]));
     SET_INT_RETURN( (mrbc_int_t)(ret & mask) );
   }

--- a/src/c_numeric.c
+++ b/src/c_numeric.c
@@ -47,11 +47,16 @@
  */
 static void c_integer_bitref(mrbc_vm *vm, mrbc_value v[], int argc)
 {
-  if( mrbc_integer(v[1]) < 0 ) {
+  const int INT_BITS = sizeof(mrbc_int_t) * CHAR_BIT;
+
+  if( mrbc_integer(v[1]) < 0 || mrbc_integer(v[1]) >= INT_BITS ||
+      (argc != 1 && mrbc_integer(v[2]) <= 0) ) {
     SET_INT_RETURN( 0 );
   } else {
-    mrbc_int_t mask = (argc == 1) ? 1 : (1 << mrbc_integer(v[2])) - 1;
-    SET_INT_RETURN( (mrbc_integer(v[0]) >> mrbc_integer(v[1])) & mask );
+    mrbc_uint_t mask = (argc == 1) ? 1 :
+      (mrbc_integer(v[2]) >= INT_BITS) ? (mrbc_uint_t)-1 : ((mrbc_uint_t)1 << mrbc_integer(v[2])) - 1;
+    mrbc_uint_t ret = (mrbc_uint_t)(mrbc_integer(v[0]) >> mrbc_integer(v[1]));
+    SET_INT_RETURN( (mrbc_int_t)(ret & mask) );
   }
 }
 

--- a/src/rrt0.c
+++ b/src/rrt0.c
@@ -45,7 +45,7 @@ static mrbc_tcb *task_queue_[NUM_TASK_QUEUE];
 #define q_waiting_   (task_queue_[2])
 #define q_suspended_ (task_queue_[3])
 static volatile uint32_t tick_;
-static volatile uint32_t wakeup_tick_ = (1 << 16); // no significant meaning.
+static volatile uint32_t wakeup_tick_ = ((uint32_t)1 << 16); // no significant meaning.
 
 
 /***** Global variables *****************************************************/
@@ -156,7 +156,7 @@ void mrbc_tick(void)
   // Check the wakeup tick.
   if( (int32_t)(wakeup_tick_ - tick_) < 0 ) {
     int flag_preemption = 0;
-    wakeup_tick_ = tick_ + (1 << 16);
+    wakeup_tick_ = tick_ + ((uint32_t)1 << 16);
 
     // Find a wake up task in waiting task queue.
     tcb = q_waiting_;

--- a/src/vm.c
+++ b/src/vm.c
@@ -310,7 +310,7 @@ mrbc_vm * mrbc_vm_open( mrbc_vm *vm )
   int vm_id;
   for( vm_id = 0; vm_id < MAX_VM_COUNT; vm_id++ ) {
     int idx = vm_id >> 4;
-    int bit = 1 << (vm_id & 0x0f);
+    uint16_t bit = (uint16_t)1 << (vm_id & 0x0f);
     if( (free_vm_bitmap[idx] & bit) == 0 ) {
       free_vm_bitmap[idx] |= bit;		// found
       break;
@@ -402,7 +402,7 @@ void mrbc_vm_close( mrbc_vm *vm )
   // free vm id.
   if( vm->vm_id != 0 ) {
     int idx = (vm->vm_id-1) >> 4;
-    int bit = 1 << ((vm->vm_id-1) & 0x0f);
+    uint16_t bit = (uint16_t)1 << ((vm->vm_id-1) & 0x0f);
     free_vm_bitmap[idx] &= ~bit;
   }
 


### PR DESCRIPTION
## Summary

This PR fixes 16-bit `int` portability issues around shift operations.

- Cast scheduler `(1 << 16)` expressions to `uint32_t` before shifting.
- Cast the allocator overflow-check operand to `uint32_t` before a 16-bit-wide right shift.
- Use an unsigned VM bitmap mask type for VM ID bit operations.
- Guard `Integer#[]` offset/width shift counts and build bit masks with `mrbc_uint_t`.

## Notes

The `MRBC_INT16` `%D` varargs issue in `src/console.c` is intentionally excluded from this PR because it is handled separately in #295.

## Validation

- Changed files compiled with 16-bit `int` settings and strong diagnostics on:
  - XC8 AVR (`AVR128DB48`)
  - AVR-GCC (`atmega2560`)
  - Clang AVR (`atmega328p`)
  - XC16 (`PIC24FJ64GA002`)
  - XC-DSC (`dsPIC33CK256MP508`)
- Full link checks succeeded on:
  - XC8 AVR (`AVR128DB48`)
  - XC16 (`PIC24FJ64GA002`, with `-mlarge-code`)
  - XC-DSC (`dsPIC33CK256MP508`, with `-mlarge-code` and the device GLD script)
- POSIX `src` build succeeded with default settings.
- POSIX `src` build succeeded with `CC='cc -DMRBC_INT16'`.
  - The remaining `console.c` `MRBC_INT16` varargs diagnostic is the separate issue covered by #295.
- `Integer#[]` smoke test under POSIX `MRBC_INT16` succeeded:
  - `5[0] => 1`
  - `5[2] => 1`
  - `5[20] => 0`
  - `5[0, 0] => 0`
  - `5[0, 16] => 5`
- `git diff --check` passed.
