### PR TITLE
Fix op_break clobbering the return value of a method with ensure

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -1919,8 +1919,12 @@ static inline void op_break( mrbc_vm *vm, mrbc_value *regs EXT )
   mrbc_set_tt( &regs[a], MRBC_TT_EMPTY );
 
   // return to the proc generated level.
+  // Check the origin (generator) of proc before the ensure handler: once we
+  // reach the generator, break lands there and its body keeps running, so its
+  // ensure must fire on the later normal return, not here. Running it now would
+  // skip the rest of the generator body and corrupt the return value.
   int reg_offset = 0;
-  while( 1 ) {
+  while( vm->callinfo_tail != vm->ret_blk->callinfo ) {
     // If have a ensure, jump to it.
     const mrbc_irep_catch_handler *handler = find_catch_handler_ensure(vm);
     if( handler ) {
@@ -1929,9 +1933,6 @@ static inline void op_break( mrbc_vm *vm, mrbc_value *regs EXT )
       vm->inst = vm->cur_irep->inst + bin_to_uint32(handler->target);
       return;
     }
-
-    // Is it the origin (generator) of proc?
-    if( vm->callinfo_tail == vm->ret_blk->callinfo ) break;
 
     reg_offset = vm->callinfo_tail->reg_offset;
     mrbc_pop_callinfo(vm);

--- a/test/ensure_break_test.rb
+++ b/test/ensure_break_test.rb
@@ -1,0 +1,63 @@
+class EnsureBreak
+  def yielder
+    yield 1
+    yield 2
+  end
+
+  # Implicit return: the method value is the last expression (`result`).
+  # `break` escapes the block; the ensure clause must not clobber the value.
+  def implicit_return
+    result = nil
+    yielder do |x|
+      result = "got#{x}"
+      break
+    end
+    result
+  ensure
+    @ensured = true
+  end
+
+  # Explicit return combined with the same block break + ensure.
+  def explicit_return
+    result = nil
+    yielder do |x|
+      result = "got#{x}"
+      break
+    end
+    return result
+  ensure
+    @ensured = true
+  end
+
+  # The break itself carries the value.
+  def break_value
+    yielder do |x|
+      break "broke#{x}"
+    end
+  ensure
+    @ensured = true
+  end
+end
+
+
+class EnsureBreakTest < Picotest::Test
+
+  def setup
+    @obj = EnsureBreak.new
+  end
+
+  description "break out of block then implicit return with ensure"
+  def test_implicit_return
+    assert_equal "got1", @obj.implicit_return
+  end
+
+  description "break out of block then explicit return with ensure"
+  def test_explicit_return
+    assert_equal "got1", @obj.explicit_return
+  end
+
+  description "break value survives the ensure clause"
+  def test_break_value
+    assert_equal "broke1", @obj.break_value
+  end
+end


### PR DESCRIPTION
A method whose body both breaks out of a block and has an ensure clause returned a wrong value (typically `self`) on mruby/c.

## Failing case

```ruby
def yielder
  yield 1
end

def read
  result = nil
  yielder do |x|
    result = "got#{x}"
    break
  end
  result
ensure
  @cleanup = true
end

read   #=> expected "got1", but returned the receiver object
```

`break` inside the block escapes `yielder` and returns control to `read` right after the `yielder(...)` call. `read` should then keep running, evaluate `result`, and return "got1"; its ensure clause should fire on that later normal return. Instead `read` returned `self`.

## Root cause

`break` unwinds the callinfo stack until it reaches the frame that generated the block (the "origin", where the break lands). While unwinding, each frame's ensure handler must run.

`op_break` ran the unwinding loop as `while(1)`, checking for an ensure handler *before* the origin check:

```c
while( 1 ) {
  handler = find_catch_handler_ensure(vm);   // checked first
  if( handler ) { jump to ensure; return; }
  if( callinfo_tail == ret_blk->callinfo ) break;   // origin, checked second
  ...
  pop_callinfo(vm);
}
```

When the loop reached the origin frame, `vm->inst` was the resume point just after the block-taking call, which lies inside the origin method's ensure-protected range. So `find_catch_handler_ensure()` matched and the loop jumped into the origin's ensure *during* the break, before noticing it had already arrived at the origin. That jump skips the rest of the origin body (the code that computes and stages the return value), and the subsequent `OP_RAISEIF` -> `CASE_OP_BREAK` continuation finishes with a freshly reset `reg_offset` of 0, writing the break value into `regs[0]` (self) instead of the call-result register. The method then returned self.

## Fix

Reorder `op_break` to match `CASE_OP_BREAK`: make the origin check the loop condition so it takes precedence over the ensure lookup. Intermediate frames between the block and the origin still run their ensures while being popped; the origin frame no longer runs its ensure during the break.