### PR TITLE
Add mrbc_task_queue_push

### DIFF
--- a/src/c_task_queue.c
+++ b/src/c_task_queue.c
@@ -111,6 +111,26 @@ static int queue_wake_all_waiters(void *q)
 
 
 //================================================================
+/*! Check whether the queue has been closed.
+
+  (NOTE)
+  @closed only ever holds true or false, so the decref is a no-op in practice.
+  It is kept to stay paired with the incref done by mrbc_instance_getiv().
+
+  @param  queue	Task::Queue instance.
+  @return	Non-zero if the queue is closed.
+*/
+static int queue_is_closed(mrbc_value *queue)
+{
+  mrbc_value closed = mrbc_instance_getiv(queue, sym_closed_);
+  int is_closed = (mrbc_type(closed) == MRBC_TT_TRUE);
+  mrbc_decref(&closed);
+
+  return is_closed;
+}
+
+
+//================================================================
 /*! (method) initialize
 */
 static void c_task_queue_initialize(mrbc_vm *vm, mrbc_value v[], int argc)
@@ -129,21 +149,22 @@ static void c_task_queue_initialize(mrbc_vm *vm, mrbc_value v[], int argc)
 */
 static void c_task_queue_push(mrbc_vm *vm, mrbc_value v[], int argc)
 {
-  mrbc_value closed = mrbc_instance_getiv(&v[0], sym_closed_);
-  int is_closed = (mrbc_type(closed) == MRBC_TT_TRUE);
-  mrbc_decref(&closed);
-  if( is_closed ) {
-    mrbc_raise(vm, task_error_class_, "queue closed");
-    return;
-  }
+  switch( mrbc_task_queue_push(&v[0], &v[1]) ) {
+  case MRBC_TASK_QUEUE_PUSH_OK:
+    break;
 
-  mrbc_value items = mrbc_instance_getiv(&v[0], sym_items_);
-  mrbc_array_push(&items, &v[1]);
-  mrbc_set_tt(&v[1], MRBC_TT_EMPTY);	// ownership moved into the array.
-  mrbc_decref(&items);
-
-  if( queue_wake_one_waiter(v[0].instance) ) {
+  case MRBC_TASK_QUEUE_PUSH_OK_WOKE:
+    // hand control back so the woken task is selected by the scheduler.
     mrbc_get_tcb(vm)->vm.flag_preemption = 1;
+    break;
+
+  case MRBC_TASK_QUEUE_PUSH_CLOSED:
+    mrbc_raise(vm, task_error_class_, "queue closed");
+    break;
+
+  case MRBC_TASK_QUEUE_PUSH_INVALID:
+    mrbc_raise(vm, MRBC_CLASS(ArgumentError), "invalid queue");
+    break;
   }
 }
 
@@ -180,10 +201,7 @@ static void c_task_queue_pop_try(mrbc_vm *vm, mrbc_value v[], int argc)
   mrbc_decref(&items);
 
   // closed and empty.
-  mrbc_value closed = mrbc_instance_getiv(&v[0], sym_closed_);
-  int is_closed = (mrbc_type(closed) == MRBC_TT_TRUE);
-  mrbc_decref(&closed);
-  if( is_closed ) {
+  if( queue_is_closed(&v[0]) ) {
     SET_NIL_RETURN();
     return;
   }
@@ -311,11 +329,7 @@ static void c_task_queue_clear(mrbc_vm *vm, mrbc_value v[], int argc)
 */
 static void c_task_queue_close(mrbc_vm *vm, mrbc_value v[], int argc)
 {
-  mrbc_value closed = mrbc_instance_getiv(&v[0], sym_closed_);
-  int was_closed = (mrbc_type(closed) == MRBC_TT_TRUE);
-  mrbc_decref(&closed);
-
-  if( !was_closed ) {
+  if( !queue_is_closed(&v[0]) ) {
     mrbc_value t = mrbc_true_value();
     mrbc_instance_setiv(&v[0], sym_closed_, &t);
     if( queue_wake_all_waiters(v[0].instance) ) {
@@ -331,10 +345,7 @@ static void c_task_queue_close(mrbc_vm *vm, mrbc_value v[], int argc)
 */
 static void c_task_queue_closed_q(mrbc_vm *vm, mrbc_value v[], int argc)
 {
-  mrbc_value closed = mrbc_instance_getiv(&v[0], sym_closed_);
-  int is_closed = (mrbc_type(closed) == MRBC_TT_TRUE);
-  mrbc_decref(&closed);
-  SET_BOOL_RETURN(is_closed);
+  SET_BOOL_RETURN( queue_is_closed(&v[0]) );
 }
 
 
@@ -401,4 +412,47 @@ void mrbc_init_task_queue(void)
   // Create the unique, private sentinels (kept for the process life).
   wait_retry_   = mrbc_instance_new(0, MRBC_CLASS(Object), 0);
   wait_timeout_ = mrbc_instance_new(0, MRBC_CLASS(Object), 0);
+}
+
+
+//================================================================
+/*! Push a value into a Task::Queue from C and wake one waiting task.
+
+  Ownership of value stays with the caller; the queue takes its own reference.
+  An invalid receiver and a closed queue are reported as a result code rather
+  than an exception, so this is usable where no VM context is at hand.
+
+  (NOTE)
+  This grows the item array through the mruby/c allocator and edits the task
+  queues, so it must NOT be called from an interrupt handler, nor from any
+  context that could re-enter the VM. There is no portable way to detect that
+  at run time, so the caller is responsible for honouring it. To feed a queue
+  from an interrupt, buffer the data in an ISR-safe ring buffer and push it
+  from a task.
+
+  A caller running inside the VM must set flag_preemption when
+  MRBC_TASK_QUEUE_PUSH_OK_WOKE is returned, otherwise the woken task waits for
+  the current time slice to expire. See c_task_queue_push().
+
+  @param  queue	Task::Queue instance (or an instance of its subclass).
+  @param  value	value to push.
+  @return	result code. see mrbc_task_queue_push_result.
+*/
+mrbc_task_queue_push_result mrbc_task_queue_push(mrbc_value *queue, mrbc_value *value)
+{
+  if( mrbc_type(*queue) != MRBC_TT_OBJECT ||
+      !mrbc_obj_is_kind_of(queue, MRBC_CLASS(Task_Queue)) ) {
+    return MRBC_TASK_QUEUE_PUSH_INVALID;
+  }
+
+  if( queue_is_closed(queue) ) return MRBC_TASK_QUEUE_PUSH_CLOSED;
+
+  mrbc_value items = mrbc_instance_getiv(queue, sym_items_);
+  assert( mrbc_type(items) == MRBC_TT_ARRAY );
+  mrbc_incref(value);
+  mrbc_array_push(&items, value);
+  mrbc_decref(&items);
+
+  return queue_wake_one_waiter(queue->instance) ?
+         MRBC_TASK_QUEUE_PUSH_OK_WOKE : MRBC_TASK_QUEUE_PUSH_OK;
 }

--- a/src/c_task_queue.h
+++ b/src/c_task_queue.h
@@ -25,10 +25,24 @@ extern "C" {
 /***** Constant values ******************************************************/
 /***** Macros ***************************************************************/
 /***** Typedefs *************************************************************/
+//================================================================
+/*!@brief
+  Result of mrbc_task_queue_push().
+*/
+typedef enum {
+  MRBC_TASK_QUEUE_PUSH_OK = 0,	//!< pushed. no task was waiting.
+  MRBC_TASK_QUEUE_PUSH_OK_WOKE,	//!< pushed and a waiting task was woken.
+  MRBC_TASK_QUEUE_PUSH_CLOSED,	//!< the queue is closed.
+  MRBC_TASK_QUEUE_PUSH_INVALID,	//!< not a Task::Queue instance.
+
+} mrbc_task_queue_push_result;
+
+
 /***** Global variables *****************************************************/
 /***** Function prototypes **************************************************/
 //@cond
 void mrbc_init_task_queue(void);
+mrbc_task_queue_push_result mrbc_task_queue_push(mrbc_value *queue, mrbc_value *value);
 //@endcond
 
 /***** Inline functions *****************************************************/

--- a/test/task_queue_test.rb
+++ b/test/task_queue_test.rb
@@ -1,4 +1,11 @@
 
+# Picotest collects the test list by loading this file in CRuby as well, where
+# Task::Queue does not exist. Define the subclass on the target VM only.
+if RUBY_ENGINE != "ruby"
+  class MyTaskQueue < Task::Queue
+  end
+end
+
 class TaskQueueTest < Picotest::Test
 
   # Only synchronous behaviour is covered here: pushing, non-blocking pop
@@ -160,5 +167,49 @@ class TaskQueueTest < Picotest::Test
   def test_pop_timeout_with_non_block
     q = Task::Queue.new
     assert_raise(ArgumentError) { q.pop(true, timeout_ms: 1) }
+  end
+
+  # __push runs the shared C entry point mrbc_task_queue_push(), which checks
+  # the receiver with a kind_of? test. These pin that subclasses stay usable.
+
+  description "a subclass of Task::Queue can push and pop"
+  def test_subclass_push_pop
+    q = MyTaskQueue.new
+    assert q.is_a?(Task::Queue)
+    q.push(1)
+    q.push(2)
+    assert_equal 1, q.pop(true)
+    assert_equal 2, q.pop(true)
+    assert q.empty?
+  end
+
+  description "a closed subclass raises Task::Error on push"
+  def test_subclass_push_after_close_raises
+    q = MyTaskQueue.new
+    q.close
+    assert_raise(Task::Error) { q.push(1) }
+  end
+
+  # push takes its own reference instead of moving the caller's, so the pushed
+  # object stays alive and usable on the caller side.
+
+  description "push keeps the caller's object, not a copy"
+  def test_push_keeps_object_identity
+    q = Task::Queue.new
+    a = [1]
+    q.push(a)
+    a << 2
+    assert_equal [1, 2], q.pop(true)
+  end
+
+  description "the same object can be pushed more than once"
+  def test_push_same_object_twice
+    q = Task::Queue.new
+    a = [1]
+    q.push(a)
+    q.push(a)
+    assert_equal [1], q.pop(true)
+    assert_equal [1], q.pop(true)
+    assert_equal [1], a
   end
 end


### PR DESCRIPTION
Add `mrbc_task_queue_push()` for delivering values from callbacks to a Task::Queue, mirroring mruby's `mrb_task_queue_push()`: https://github.com/mruby/mruby/pull/6955

The API reports invalid and closed queues using status codes, allowing callback callers to handle these expected conditions without exception handling. Exceptions caused by allocation or other mruby/c internals may still propagate.

This API must not be called from an interrupt handler or any context that would re-enter the VM. It may allocate memory and modifies VM scheduler state.

PicoRuby's BLE implementation for Raspberry Pi Pico W uses pico_cyw43_arch_lwip_poll rather than threadsafe_background, so its callbacks run synchronously in a context where pushing a Ruby object is permitted.