### PR TITLE
Fix Use-After-Free

### DIFF
--- a/src/c_object.c
+++ b/src/c_object.c
@@ -777,7 +777,9 @@ static void c_object_sprintf(mrbc_vm *vm, mrbc_value v[], int argc)
   mrbc_printf_end( &pf );
 
   buflen = mrbc_printf_len( &pf );
-  mrbc_realloc(vm, pf.buf, buflen+1);	// shrink suitable size.
+  // shrink suitable size. realloc() may move the block.
+  buf = mrbc_realloc(vm, pf.buf, buflen+1);
+  if( buf ) mrbc_printf_replace_buffer(&pf, buf, buflen+1);
 
   mrbc_value value = mrbc_string_new_alloc( vm, pf.buf, buflen );
 

--- a/src/c_string.c
+++ b/src/c_string.c
@@ -117,7 +117,9 @@ void mrbc_string_delete(mrbc_value *str)
 */
 void mrbc_string_clear(mrbc_value *str)
 {
-  mrbc_raw_realloc(str->string->data, 1);
+  // shrink suitable size. realloc() may move the block.
+  uint8_t *buf = mrbc_raw_realloc(str->string->data, 1);
+  if( buf ) str->string->data = buf;
   str->string->data[0] = '\0';
   str->string->size = 0;
 }
@@ -288,7 +290,9 @@ int mrbc_string_strip(mrbc_value *src, int mode)
   char *buf = mrbc_string_cstr(src);
   if( p1 != buf ) memmove( buf, p1, new_size );
   buf[new_size] = '\0';
-  mrbc_raw_realloc(buf, new_size+1);	// shrink suitable size.
+  // shrink suitable size. realloc() may move the block.
+  uint8_t *buf2 = mrbc_raw_realloc(buf, new_size+1);
+  if( buf2 ) src->string->data = buf2;
   src->string->size = new_size;
 
   return 1;
@@ -1499,7 +1503,9 @@ static void c_string_slice_self(mrbc_vm *vm, mrbc_value v[], int argc)
     memmove( mrbc_string_cstr(v) + byte_pos, mrbc_string_cstr(v) + byte_pos + byte_len,
              byte_size - byte_pos - byte_len + 1 );
     v->string->size = byte_size - byte_len;
-    mrbc_raw_realloc( mrbc_string_cstr(v), v->string->size + 1 );
+    // shrink suitable size. realloc() may move the block.
+    uint8_t *buf = mrbc_raw_realloc( mrbc_string_cstr(v), v->string->size + 1 );
+    if( buf ) v->string->data = buf;
   }
 #else
   mrbc_value ret = mrbc_string_new(vm, mrbc_string_cstr(v) + pos, len);
@@ -1508,7 +1514,9 @@ static void c_string_slice_self(mrbc_vm *vm, mrbc_value v[], int argc)
     memmove( mrbc_string_cstr(v) + pos, mrbc_string_cstr(v) + pos + len,
              mrbc_string_size(v) - pos - len + 1 );
     v->string->size = mrbc_string_size(v) - len;
-    mrbc_raw_realloc( mrbc_string_cstr(v), mrbc_string_size(v)+1 );
+    // shrink suitable size. realloc() may move the block.
+    uint8_t *buf = mrbc_raw_realloc( mrbc_string_cstr(v), mrbc_string_size(v)+1 );
+    if( buf ) v->string->data = buf;
   }
 #endif
 


### PR DESCRIPTION
In the `realloc` call intended to shrink the memory to a suitable size, the return value was discarded, and the old pointer continued to be used.

This issue does not show with mruby/c's custom allocator because blocks do not move during shrinkage; however, it produces a bug when using `MRBC_ALLOC_LIBC` (libc's `realloc`), as the block may be relocated.