### PR TITLE
Fix unaligned access to irep->tbl_ireps on 64-bit targets

### DIFF
--- a/src/load.c
+++ b/src/load.c
@@ -192,8 +192,11 @@ static mrbc_irep * load_irep_1(mrbc_vm *vm, const uint8_t *bin, int *len)
   irep.ofs_pools = siz;
 
   siz += sizeof(uint16_t) * plen;
+  // tbl_ireps holds pointers, so align to the pointer size.
+  //  in 32bit: sizeof(mrbc_irep *) - 1 = 0x03
+  //  in 64bit: sizeof(mrbc_irep *) - 1 = 0x07
+  siz += (-siz & (uint32_t)(sizeof(mrbc_irep *) - 1));
   if( siz > 0xffff ) goto ERROR_TOO_LARGE;
-  siz += (-siz & 0x03);	// padding. 32bit align.
   irep.ofs_ireps = siz;
 
 #if defined(MRBC_DEBUG)

--- a/src/vm.h
+++ b/src/vm.h
@@ -58,7 +58,7 @@ typedef struct IREP {
   uint16_t slen;		//!< num of symbols
 #endif
   uint16_t ofs_pools;		//!< offset of data->tbl_pools.
-  uint16_t ofs_ireps;		//!< offset of data->tbl_ireps. (32bit aligned)
+  uint16_t ofs_ireps;		//!< offset of data->tbl_ireps. (pointer aligned)
 
   const uint8_t *inst;		//!< pointer to instruction in RITE binary
   const uint8_t *pool;		//!< pointer to pool in RITE binary


### PR DESCRIPTION
tbl_ireps is an array of `mrbc_irep *`, but the padding in front of it in irep->data was rounded up to 4 bytes only. On a 64-bit target a pointer is 8 bytes, so tbl_ireps lands on a 4-mod-8 address whenever (slen + plen) % 4 is 1 or 2, and load_irep() then stores pointers there unaligned. That is undefined behavior.

x86-64 and arm64 tolerate unaligned loads and stores in hardware, so it happens to work today. It can still break on a strict-alignment 64-bit target, or if the compiler vectorizes the store loop with instructions that assume alignment.

Also, the "Too large IREP size" check now runs after the padding, since the padding adds up to 7 bytes and could otherwise push siz past the uint16_t range and silently truncate irep.ofs_ireps.

I found this issue while building PicoRuby with Fil-C https://fil-c.org/