### PR TITLE
Fix Integer comparison using an untruncated difference

### DIFF
--- a/src/value.c
+++ b/src/value.c
@@ -102,8 +102,11 @@ int mrbc_compare(const mrbc_value *v1, const mrbc_value *v2)
   case MRBC_TT_TRUE:
     return 0;
 
-  case MRBC_TT_INTEGER:
-    return mrbc_integer(*v1) - mrbc_integer(*v2);
+  case MRBC_TT_INTEGER: {
+    mrbc_int_t i1 = mrbc_integer(*v1);
+    mrbc_int_t i2 = mrbc_integer(*v2);
+    return -1 + (i1 == i2) + (i1 > i2)*2;
+  }
 
   case MRBC_TT_SYMBOL: {
     const char *str1 = mrbc_symid_to_str(mrbc_symbol(*v1));

--- a/test/op_basic_test.rb
+++ b/test/op_basic_test.rb
@@ -234,4 +234,17 @@ class OpBasicTest < Picotest::Test
     assert_true( a >= b )
   end
 
+  description "op_compare with a difference that does not fit in int"
+  def test_op_compare_wide_difference
+    a = 2000000000
+    b = -2000000000
+    assert_false( a < b )
+    assert_false( a <= b )
+    assert_true( a > b )
+    assert_true( a >= b )
+    assert_true( b < a )
+    assert_equal( 1, a <=> b )
+    assert_equal( -1, b <=> a )
+  end
+
 end


### PR DESCRIPTION
mrbc_compare() returned `mrbc_integer(*v1) - mrbc_integer(*v2)` for MRBC_TT_INTEGER. The return type is int, so on an MRBC_INT64 build that 64-bit difference is truncated to 32 bits, and on any build the subtraction itself can overflow. Either way the sign of the result, which is all the callers look at, can come out wrong.

Every Integer comparison goes through this. op_lt, op_le, op_gt and op_ge call mrbc_compare() in vm.c; Object#==, #!=, #=== and #<=> call it in c_object.c; Integer#clamp calls it in c_numeric.c; and mrbc_hash_search() matches keys with `mrbc_compare(...) == 0` in c_hash.c, so a difference that truncates to zero also makes two different Hash keys collide.

Observed on a 64-bit build before this change:

    0 < -2147483648             #=> true
    1 == 4294967297             #=> true
    0 <=> 4294967296            #=> 0
    2000000000 <=> -2000000000  #=> -294967296

Return -1, 0 or 1 instead, in the same form the float branch of this function already uses. That also makes <=> return -1, 0 or 1 as Ruby specifies rather than an arbitrary difference.

The test uses 2000000000 and -2000000000 so that it reproduces on 32-bit and 64-bit MRBC_INT builds alike: their difference leaves the range of a 32-bit int in both cases.