### PR TITLE
Suggestion: Do not fail the whole irep load on an unsupported integer literal

### DIFF
--- a/src/load.c
+++ b/src/load.c
@@ -167,15 +167,10 @@ static mrbc_irep * load_irep_1(mrbc_vm *vm, const uint8_t *bin, int *len)
     case IREP_TT_SSTR:   siz = bin_to_uint16(p) + 3; break;
     case IREP_TT_INT32:  siz = 4; break;
 
-#if defined(MRBC_INT64)
+    // an unsupported literal is skipped here and raises when it is used.
+    // (see mrbc_irep_pool_value)
     case IREP_TT_INT64:  siz = 8; break;
     case IREP_TT_BIGINT: siz = *p + 2; break;
-#else
-    case IREP_TT_INT64:
-    case IREP_TT_BIGINT:
-       mrbc_raise(vm, MRBC_CLASS(NotImplementedError), "Unsupported int64 (set MRBC_INT64 in vm_config)");
-       return NULL;
-#endif
 
     case IREP_TT_FLOAT: siz = 8; break;
     default:
@@ -246,10 +241,8 @@ static mrbc_irep * load_irep_1(mrbc_vm *vm, const uint8_t *bin, int *len)
     case IREP_TT_STR:
     case IREP_TT_SSTR:   siz = bin_to_uint16(p) + 3; break;
     case IREP_TT_INT32:  siz = 4; break;
-#if defined(MRBC_INT64)
     case IREP_TT_INT64:  siz = 8; break;
     case IREP_TT_BIGINT: siz = *p + 2; break;
-#endif
     case IREP_TT_FLOAT:	siz = 8;  break;
     }
     p += siz;
@@ -431,6 +424,12 @@ mrbc_value mrbc_irep_pool_value(mrbc_vm *vm, int n)
 
   case IREP_TT_BIGINT:
     mrbc_set_integer(&obj, conv_bigint(p));
+    break;
+#else
+  case IREP_TT_INT64:
+  case IREP_TT_BIGINT:
+    mrbc_raise(vm, MRBC_CLASS(NotImplementedError), "Unsupported int64 (set MRBC_INT64 in vm_config)");
+    mrbc_set_nil(&obj);
     break;
 #endif
 


### PR DESCRIPTION
## Background

`load_irep_1()` raised and returned NULL as soon as it saw an `IREP_TT_INT64` or `IREP_TT_BIGINT` pool entry in a build without `MRBC_INT64`.
That error propagates through `load_irep()` and `mrbc_load_irep()` up to `mrbc_load_mrb()`, so one literal the program may never evaluate aborts the load of the entire bytecode chunk and takes every class and method defined in it down with it.

## Suggestion

Skip the entry instead.
Its size is known and does not depend on the integer width: 8 bytes for INT64, and for BIGINT the length byte plus the base byte plus that many digits, which is what `conv_bigint()` reads.
The error moves to `mrbc_irep_pool_value()`, which runs only when the VM actually fetches the literal.

A build that cannot represent the value still cannot use it. Only the code that touches it fails now, instead of everything around it.